### PR TITLE
Add bytes-based API for in-memory audio processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.2.0
+
+* Add bytes-based API for in-memory audio processing — no file paths needed.
+  * `convertToWavBytes` — convert audio bytes to WAV format.
+  * `convertToM4aBytes` — convert audio bytes to M4A format.
+  * `getAudioInfoBytes` — retrieve metadata from audio bytes.
+  * `trimAudioBytes` — trim audio bytes to a time range.
+  * `getWaveformBytes` — extract waveform data from audio bytes.
+* All bytes methods accept a `formatHint` parameter to indicate the input format.
+* Ideal for network responses, Flutter assets, and other in-memory audio sources.
+
 ## 0.1.0
 
 * Initial release of `audio_decoder`.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A lightweight Flutter plugin for converting, trimming, and analyzing audio files
 - Get audio metadata (duration, sample rate, channels, bit rate, format)
 - Trim audio files to a specific time range
 - Extract waveform amplitude data for visualization
+- **Bytes API** — work with in-memory audio (`Uint8List`) without file paths
 - Uses native platform APIs — no bundled codecs or heavy dependencies
 - Supports Android, iOS, macOS, and Windows
 - Minimal app size impact (~500KB vs ~15-30MB for FFmpeg)
@@ -30,7 +31,7 @@ Add `audio_decoder` to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  audio_decoder: ^0.1.0
+  audio_decoder: ^0.2.0
 ```
 
 Or install via the command line:
@@ -97,6 +98,46 @@ final waveform = await AudioDecoder.getWaveform(
 );
 // waveform = [0.12, 0.45, 0.87, 0.23, ...]
 ```
+
+### Bytes API (in-memory)
+
+Work directly with audio bytes — no file paths needed. Ideal for network responses, Flutter assets, or other in-memory sources.
+
+```dart
+import 'dart:typed_data';
+
+// Load audio bytes from any source
+final Uint8List mp3Bytes = await fetchFromNetwork();
+
+// Convert bytes to WAV
+final wavBytes = await AudioDecoder.convertToWavBytes(
+  mp3Bytes,
+  formatHint: 'mp3',
+);
+
+// Get metadata from bytes
+final info = await AudioDecoder.getAudioInfoBytes(
+  mp3Bytes,
+  formatHint: 'mp3',
+);
+
+// Trim audio bytes
+final trimmed = await AudioDecoder.trimAudioBytes(
+  mp3Bytes,
+  formatHint: 'mp3',
+  start: Duration(seconds: 10),
+  end: Duration(seconds: 30),
+);
+
+// Extract waveform from bytes
+final waveform = await AudioDecoder.getWaveformBytes(
+  mp3Bytes,
+  formatHint: 'mp3',
+  numberOfSamples: 100,
+);
+```
+
+The `formatHint` parameter tells the native decoder what format the bytes are in (e.g., `'mp3'`, `'m4a'`, `'wav'`, `'aac'`).
 
 ### Error handling
 

--- a/lib/audio_decoder.dart
+++ b/lib/audio_decoder.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'audio_decoder_platform_interface.dart';
 import 'audio_info.dart';
 
@@ -100,5 +102,70 @@ class AudioDecoder {
       return false;
     }
     return supportedExtensions.any((ext) => lower.endsWith(ext));
+  }
+
+  /// Converts audio bytes to WAV format.
+  ///
+  /// [inputData] is the raw bytes of the source audio file.
+  /// [formatHint] indicates the input format (e.g., 'mp3', 'm4a', 'aac').
+  ///
+  /// Returns the WAV file bytes.
+  /// Throws [AudioConversionException] on failure.
+  static Future<Uint8List> convertToWavBytes(Uint8List inputData, {required String formatHint}) {
+    return AudioDecoderPlatform.instance.convertToWavBytes(inputData, formatHint);
+  }
+
+  /// Converts audio bytes to M4A (AAC) format.
+  ///
+  /// [inputData] is the raw bytes of the source audio file.
+  /// [formatHint] indicates the input format (e.g., 'mp3', 'wav', 'flac').
+  ///
+  /// Returns the M4A file bytes.
+  /// Throws [AudioConversionException] on failure.
+  static Future<Uint8List> convertToM4aBytes(Uint8List inputData, {required String formatHint}) {
+    return AudioDecoderPlatform.instance.convertToM4aBytes(inputData, formatHint);
+  }
+
+  /// Returns metadata about the audio data in [inputData].
+  ///
+  /// [formatHint] indicates the input format (e.g., 'mp3', 'm4a').
+  /// Includes duration, sample rate, channel count, bit rate, and format.
+  /// Throws [AudioConversionException] if the data cannot be read.
+  static Future<AudioInfo> getAudioInfoBytes(Uint8List inputData, {required String formatHint}) {
+    return AudioDecoderPlatform.instance.getAudioInfoBytes(inputData, formatHint);
+  }
+
+  /// Trims audio bytes to the specified time range.
+  ///
+  /// [inputData] is the raw bytes of the source audio file.
+  /// [formatHint] indicates the input format (e.g., 'mp3', 'm4a').
+  /// [start] and [end] define the time range to extract.
+  /// [outputFormat] determines the output encoding ('wav' or 'm4a').
+  ///
+  /// Returns the trimmed audio bytes.
+  /// Throws [AudioConversionException] on failure.
+  static Future<Uint8List> trimAudioBytes(
+    Uint8List inputData, {
+    required String formatHint,
+    required Duration start,
+    required Duration end,
+    String outputFormat = 'wav',
+  }) {
+    return AudioDecoderPlatform.instance.trimAudioBytes(inputData, formatHint, start, end, outputFormat: outputFormat);
+  }
+
+  /// Extracts waveform amplitude data from audio bytes.
+  ///
+  /// [inputData] is the raw bytes of the source audio file.
+  /// [formatHint] indicates the input format (e.g., 'mp3', 'm4a').
+  /// Returns a list of [numberOfSamples] normalized amplitude values (0.0–1.0).
+  ///
+  /// Throws [AudioConversionException] if the data cannot be decoded.
+  static Future<List<double>> getWaveformBytes(
+    Uint8List inputData, {
+    required String formatHint,
+    int numberOfSamples = 100,
+  }) {
+    return AudioDecoderPlatform.instance.getWaveformBytes(inputData, formatHint, numberOfSamples);
   }
 }

--- a/lib/audio_decoder_method_channel.dart
+++ b/lib/audio_decoder_method_channel.dart
@@ -114,4 +114,111 @@ class MethodChannelAudioDecoder extends AudioDecoderPlatform {
       );
     }
   }
+
+  @override
+  Future<Uint8List> convertToWavBytes(Uint8List inputData, String formatHint) async {
+    try {
+      final result = await methodChannel.invokeMethod<Uint8List>(
+        'convertToWavBytes',
+        {'inputData': inputData, 'formatHint': formatHint},
+      );
+      if (result == null) {
+        throw AudioConversionException('Native conversion returned null');
+      }
+      return result;
+    } on PlatformException catch (e) {
+      throw AudioConversionException(
+        e.message ?? 'Unknown conversion error',
+        details: e.details?.toString(),
+      );
+    }
+  }
+
+  @override
+  Future<Uint8List> convertToM4aBytes(Uint8List inputData, String formatHint) async {
+    try {
+      final result = await methodChannel.invokeMethod<Uint8List>(
+        'convertToM4aBytes',
+        {'inputData': inputData, 'formatHint': formatHint},
+      );
+      if (result == null) {
+        throw AudioConversionException('Native conversion returned null');
+      }
+      return result;
+    } on PlatformException catch (e) {
+      throw AudioConversionException(
+        e.message ?? 'Unknown conversion error',
+        details: e.details?.toString(),
+      );
+    }
+  }
+
+  @override
+  Future<AudioInfo> getAudioInfoBytes(Uint8List inputData, String formatHint) async {
+    try {
+      final result = await methodChannel.invokeMapMethod<String, dynamic>(
+        'getAudioInfoBytes',
+        {'inputData': inputData, 'formatHint': formatHint},
+      );
+      if (result == null) {
+        throw AudioConversionException('Native getAudioInfo returned null');
+      }
+      return AudioInfo(
+        duration: Duration(milliseconds: result['durationMs'] as int),
+        sampleRate: result['sampleRate'] as int,
+        channels: result['channels'] as int,
+        bitRate: result['bitRate'] as int,
+        format: result['format'] as String,
+      );
+    } on PlatformException catch (e) {
+      throw AudioConversionException(
+        e.message ?? 'Unknown error',
+        details: e.details?.toString(),
+      );
+    }
+  }
+
+  @override
+  Future<Uint8List> trimAudioBytes(Uint8List inputData, String formatHint, Duration start, Duration end, {String outputFormat = 'wav'}) async {
+    try {
+      final result = await methodChannel.invokeMethod<Uint8List>(
+        'trimAudioBytes',
+        {
+          'inputData': inputData,
+          'formatHint': formatHint,
+          'startMs': start.inMilliseconds,
+          'endMs': end.inMilliseconds,
+          'outputFormat': outputFormat,
+        },
+      );
+      if (result == null) {
+        throw AudioConversionException('Native trimAudio returned null');
+      }
+      return result;
+    } on PlatformException catch (e) {
+      throw AudioConversionException(
+        e.message ?? 'Unknown error',
+        details: e.details?.toString(),
+      );
+    }
+  }
+
+  @override
+  Future<List<double>> getWaveformBytes(Uint8List inputData, String formatHint, int numberOfSamples) async {
+    try {
+      final result = await methodChannel.invokeListMethod<double>(
+        'getWaveformBytes',
+        {'inputData': inputData, 'formatHint': formatHint, 'numberOfSamples': numberOfSamples},
+      );
+      if (result == null) {
+        throw AudioConversionException('Native getWaveform returned null');
+      }
+      return result;
+    } on PlatformException catch (e) {
+      throw AudioConversionException(
+        e.message ?? 'Unknown error',
+        details: e.details?.toString(),
+      );
+    }
+  }
 }

--- a/lib/audio_decoder_platform_interface.dart
+++ b/lib/audio_decoder_platform_interface.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'audio_decoder_method_channel.dart';
@@ -35,5 +37,25 @@ abstract class AudioDecoderPlatform extends PlatformInterface {
 
   Future<List<double>> getWaveform(String path, int numberOfSamples) {
     throw UnimplementedError('getWaveform() has not been implemented.');
+  }
+
+  Future<Uint8List> convertToWavBytes(Uint8List inputData, String formatHint) {
+    throw UnimplementedError('convertToWavBytes() has not been implemented.');
+  }
+
+  Future<Uint8List> convertToM4aBytes(Uint8List inputData, String formatHint) {
+    throw UnimplementedError('convertToM4aBytes() has not been implemented.');
+  }
+
+  Future<AudioInfo> getAudioInfoBytes(Uint8List inputData, String formatHint) {
+    throw UnimplementedError('getAudioInfoBytes() has not been implemented.');
+  }
+
+  Future<Uint8List> trimAudioBytes(Uint8List inputData, String formatHint, Duration start, Duration end, {String outputFormat = 'wav'}) {
+    throw UnimplementedError('trimAudioBytes() has not been implemented.');
+  }
+
+  Future<List<double>> getWaveformBytes(Uint8List inputData, String formatHint, int numberOfSamples) {
+    throw UnimplementedError('getWaveformBytes() has not been implemented.');
   }
 }

--- a/macos/Classes/AudioDecoderPlugin.swift
+++ b/macos/Classes/AudioDecoderPlugin.swift
@@ -75,6 +75,50 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
                 return
             }
             getWaveform(path: path, numberOfSamples: numberOfSamples, result: result)
+        case "convertToWavBytes":
+            guard let args = call.arguments as? [String: Any],
+                  let inputData = args["inputData"] as? FlutterStandardTypedData,
+                  let formatHint = args["formatHint"] as? String else {
+                result(FlutterError(code: "INVALID_ARGUMENTS", message: "inputData and formatHint are required", details: nil))
+                return
+            }
+            convertToWavBytes(inputData: inputData, formatHint: formatHint, result: result)
+        case "convertToM4aBytes":
+            guard let args = call.arguments as? [String: Any],
+                  let inputData = args["inputData"] as? FlutterStandardTypedData,
+                  let formatHint = args["formatHint"] as? String else {
+                result(FlutterError(code: "INVALID_ARGUMENTS", message: "inputData and formatHint are required", details: nil))
+                return
+            }
+            convertToM4aBytes(inputData: inputData, formatHint: formatHint, result: result)
+        case "getAudioInfoBytes":
+            guard let args = call.arguments as? [String: Any],
+                  let inputData = args["inputData"] as? FlutterStandardTypedData,
+                  let formatHint = args["formatHint"] as? String else {
+                result(FlutterError(code: "INVALID_ARGUMENTS", message: "inputData and formatHint are required", details: nil))
+                return
+            }
+            getAudioInfoBytes(inputData: inputData, formatHint: formatHint, result: result)
+        case "trimAudioBytes":
+            guard let args = call.arguments as? [String: Any],
+                  let inputData = args["inputData"] as? FlutterStandardTypedData,
+                  let formatHint = args["formatHint"] as? String,
+                  let startMs = args["startMs"] as? Int,
+                  let endMs = args["endMs"] as? Int else {
+                result(FlutterError(code: "INVALID_ARGUMENTS", message: "inputData, formatHint, startMs and endMs are required", details: nil))
+                return
+            }
+            let outputFormat = args["outputFormat"] as? String ?? "wav"
+            trimAudioBytes(inputData: inputData, formatHint: formatHint, startMs: startMs, endMs: endMs, outputFormat: outputFormat, result: result)
+        case "getWaveformBytes":
+            guard let args = call.arguments as? [String: Any],
+                  let inputData = args["inputData"] as? FlutterStandardTypedData,
+                  let formatHint = args["formatHint"] as? String,
+                  let numberOfSamples = args["numberOfSamples"] as? Int else {
+                result(FlutterError(code: "INVALID_ARGUMENTS", message: "inputData, formatHint and numberOfSamples are required", details: nil))
+                return
+            }
+            getWaveformBytes(inputData: inputData, formatHint: formatHint, numberOfSamples: numberOfSamples, result: result)
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -538,6 +582,128 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
         }
 
         return waveform
+    }
+
+    // MARK: - Temp file helper
+
+    private func writeTempInput(data: FlutterStandardTypedData, formatHint: String) throws -> URL {
+        let tempDir = FileManager.default.temporaryDirectory
+        let fileName = "audio_decoder_in_\(ProcessInfo.processInfo.globallyUniqueString).\(formatHint)"
+        let url = tempDir.appendingPathComponent(fileName)
+        try data.data.write(to: url)
+        return url
+    }
+
+    private func tempOutputURL(ext: String) -> URL {
+        let tempDir = FileManager.default.temporaryDirectory
+        let fileName = "audio_decoder_out_\(ProcessInfo.processInfo.globallyUniqueString).\(ext)"
+        return tempDir.appendingPathComponent(fileName)
+    }
+
+    // MARK: - Bytes-based methods
+
+    private func convertToWavBytes(inputData: FlutterStandardTypedData, formatHint: String, result: @escaping FlutterResult) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let tempInputURL = try self.writeTempInput(data: inputData, formatHint: formatHint)
+                let tempOutputURL = self.tempOutputURL(ext: "wav")
+                defer {
+                    try? FileManager.default.removeItem(at: tempInputURL)
+                    try? FileManager.default.removeItem(at: tempOutputURL)
+                }
+                try self.performConversion(inputPath: tempInputURL.path, outputPath: tempOutputURL.path)
+                let outputData = try Data(contentsOf: tempOutputURL)
+                DispatchQueue.main.async {
+                    result(FlutterStandardTypedData(bytes: outputData))
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    result(FlutterError(code: "CONVERSION_ERROR", message: error.localizedDescription, details: nil))
+                }
+            }
+        }
+    }
+
+    private func convertToM4aBytes(inputData: FlutterStandardTypedData, formatHint: String, result: @escaping FlutterResult) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let tempInputURL = try self.writeTempInput(data: inputData, formatHint: formatHint)
+                let tempOutputURL = self.tempOutputURL(ext: "m4a")
+                defer {
+                    try? FileManager.default.removeItem(at: tempInputURL)
+                    try? FileManager.default.removeItem(at: tempOutputURL)
+                }
+                try self.performM4aConversion(inputPath: tempInputURL.path, outputPath: tempOutputURL.path)
+                let outputData = try Data(contentsOf: tempOutputURL)
+                DispatchQueue.main.async {
+                    result(FlutterStandardTypedData(bytes: outputData))
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    result(FlutterError(code: "CONVERSION_ERROR", message: error.localizedDescription, details: nil))
+                }
+            }
+        }
+    }
+
+    private func getAudioInfoBytes(inputData: FlutterStandardTypedData, formatHint: String, result: @escaping FlutterResult) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let tempInputURL = try self.writeTempInput(data: inputData, formatHint: formatHint)
+                defer {
+                    try? FileManager.default.removeItem(at: tempInputURL)
+                }
+                let info = try self.performGetAudioInfo(path: tempInputURL.path)
+                DispatchQueue.main.async {
+                    result(info)
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    result(FlutterError(code: "INFO_ERROR", message: error.localizedDescription, details: nil))
+                }
+            }
+        }
+    }
+
+    private func trimAudioBytes(inputData: FlutterStandardTypedData, formatHint: String, startMs: Int, endMs: Int, outputFormat: String, result: @escaping FlutterResult) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let tempInputURL = try self.writeTempInput(data: inputData, formatHint: formatHint)
+                let tempOutputURL = self.tempOutputURL(ext: outputFormat)
+                defer {
+                    try? FileManager.default.removeItem(at: tempInputURL)
+                    try? FileManager.default.removeItem(at: tempOutputURL)
+                }
+                try self.performTrimAudio(inputPath: tempInputURL.path, outputPath: tempOutputURL.path, startMs: startMs, endMs: endMs)
+                let outputData = try Data(contentsOf: tempOutputURL)
+                DispatchQueue.main.async {
+                    result(FlutterStandardTypedData(bytes: outputData))
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    result(FlutterError(code: "TRIM_ERROR", message: error.localizedDescription, details: nil))
+                }
+            }
+        }
+    }
+
+    private func getWaveformBytes(inputData: FlutterStandardTypedData, formatHint: String, numberOfSamples: Int, result: @escaping FlutterResult) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let tempInputURL = try self.writeTempInput(data: inputData, formatHint: formatHint)
+                defer {
+                    try? FileManager.default.removeItem(at: tempInputURL)
+                }
+                let waveform = try self.performGetWaveform(path: tempInputURL.path, numberOfSamples: numberOfSamples)
+                DispatchQueue.main.async {
+                    result(waveform)
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    result(FlutterError(code: "WAVEFORM_ERROR", message: error.localizedDescription, details: nil))
+                }
+            }
+        }
     }
 
     // MARK: - WAV writing helper

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_decoder
 description: "A lightweight Flutter plugin for converting, trimming, and analyzing audio files using native platform APIs. No FFmpeg required."
-version: 0.1.0
+version: 0.2.0
 homepage: https://www.silversoft.nl
 repository: https://github.com/sjoenk/audio_decoder
 

--- a/windows/audio_decoder_plugin.h
+++ b/windows/audio_decoder_plugin.h
@@ -48,6 +48,11 @@ class AudioDecoderPlugin : public flutter::Plugin {
   };
   PcmResult DecodeToPcm(const std::string& inputPath,
                          int64_t startMs = -1, int64_t endMs = -1);
+
+  // Temp file helpers for bytes-based API
+  std::string WriteTempFile(const std::vector<uint8_t>& data,
+                            const std::string& extension);
+  std::vector<uint8_t> ReadAndDeleteFile(const std::string& path);
 };
 
 }  // namespace audio_decoder

--- a/windows/test/audio_decoder_plugin_test.cpp
+++ b/windows/test/audio_decoder_plugin_test.cpp
@@ -80,5 +80,75 @@ TEST(AudioDecoderPlugin, ConvertToWavMissingPathsReturnsError) {
   EXPECT_EQ(error_code, "INVALID_ARGUMENTS");
 }
 
+TEST(AudioDecoderPlugin, ConvertToWavBytesMissingArgsReturnsError) {
+  AudioDecoderPlugin plugin;
+  std::string error_code;
+  plugin.HandleMethodCall(
+      MethodCall("convertToWavBytes", std::make_unique<EncodableValue>()),
+      std::make_unique<MethodResultFunctions<>>(
+          nullptr,
+          [&error_code](const std::string& code, const std::string&,
+                        const EncodableValue*) { error_code = code; },
+          nullptr));
+
+  EXPECT_EQ(error_code, "INVALID_ARGUMENTS");
+}
+
+TEST(AudioDecoderPlugin, ConvertToM4aBytesMissingArgsReturnsError) {
+  AudioDecoderPlugin plugin;
+  std::string error_code;
+  plugin.HandleMethodCall(
+      MethodCall("convertToM4aBytes", std::make_unique<EncodableValue>()),
+      std::make_unique<MethodResultFunctions<>>(
+          nullptr,
+          [&error_code](const std::string& code, const std::string&,
+                        const EncodableValue*) { error_code = code; },
+          nullptr));
+
+  EXPECT_EQ(error_code, "INVALID_ARGUMENTS");
+}
+
+TEST(AudioDecoderPlugin, GetAudioInfoBytesMissingArgsReturnsError) {
+  AudioDecoderPlugin plugin;
+  std::string error_code;
+  plugin.HandleMethodCall(
+      MethodCall("getAudioInfoBytes", std::make_unique<EncodableValue>()),
+      std::make_unique<MethodResultFunctions<>>(
+          nullptr,
+          [&error_code](const std::string& code, const std::string&,
+                        const EncodableValue*) { error_code = code; },
+          nullptr));
+
+  EXPECT_EQ(error_code, "INVALID_ARGUMENTS");
+}
+
+TEST(AudioDecoderPlugin, TrimAudioBytesMissingArgsReturnsError) {
+  AudioDecoderPlugin plugin;
+  std::string error_code;
+  plugin.HandleMethodCall(
+      MethodCall("trimAudioBytes", std::make_unique<EncodableValue>()),
+      std::make_unique<MethodResultFunctions<>>(
+          nullptr,
+          [&error_code](const std::string& code, const std::string&,
+                        const EncodableValue*) { error_code = code; },
+          nullptr));
+
+  EXPECT_EQ(error_code, "INVALID_ARGUMENTS");
+}
+
+TEST(AudioDecoderPlugin, GetWaveformBytesMissingArgsReturnsError) {
+  AudioDecoderPlugin plugin;
+  std::string error_code;
+  plugin.HandleMethodCall(
+      MethodCall("getWaveformBytes", std::make_unique<EncodableValue>()),
+      std::make_unique<MethodResultFunctions<>>(
+          nullptr,
+          [&error_code](const std::string& code, const std::string&,
+                        const EncodableValue*) { error_code = code; },
+          nullptr));
+
+  EXPECT_EQ(error_code, "INVALID_ARGUMENTS");
+}
+
 }  // namespace test
 }  // namespace audio_decoder


### PR DESCRIPTION
## Summary

- Add 5 new `*Bytes` methods (`convertToWavBytes`, `convertToM4aBytes`, `getAudioInfoBytes`, `trimAudioBytes`, `getWaveformBytes`) that accept `Uint8List` input with a `formatHint` parameter
- Implement native handlers on all 4 platforms (Android, iOS, macOS, Windows) using a temp-file strategy for maximum code reuse
- Add unit tests (32 total, all passing) and example app demo section
- Bump version to 0.2.0 with updated changelog and readme

## Test plan

- [x] `flutter test` — 32/32 tests pass
- [x] `dart analyze` — no issues
- [x] Manual testing on macOS with example app
- [x] Manual testing on iOS with example app
- [x] Manual testing on Android with example app
- [x] Manual testing on Windows with example app