### PR TITLE
Add web support using Web Audio API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.4.0
+
+* Add web support using the Web Audio API.
+* Bytes-based methods (`convertToWavBytes`, `getAudioInfoBytes`, `trimAudioBytes`, `getWaveformBytes`) are fully supported on web.
+* File-based methods throw `UnsupportedError` on web — use the bytes API instead.
+* M4A encoding is not available on web (browser limitation).
+
 ## 0.3.0
 
 * Add Linux support using GStreamer.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A lightweight Flutter plugin for converting, trimming, and analyzing audio files
 - Extract waveform amplitude data for visualization
 - **Bytes API** — work with in-memory audio (`Uint8List`) without file paths
 - Uses native platform APIs — no bundled codecs or heavy dependencies
-- Supports Android, iOS, macOS, Windows, and Linux
+- Supports Android, iOS, macOS, Windows, Linux, and Web
 - Minimal app size impact (~500KB vs ~15-30MB for FFmpeg)
 
 ## Platform APIs
@@ -25,6 +25,7 @@ A lightweight Flutter plugin for converting, trimming, and analyzing audio files
 | Android | MediaExtractor + MediaCodec |
 | Windows | Media Foundation (IMFSourceReader) |
 | Linux | GStreamer |
+| Web | Web Audio API |
 
 ## Getting started
 
@@ -32,7 +33,7 @@ Add `audio_decoder` to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  audio_decoder: ^0.3.0
+  audio_decoder: ^0.4.0
 ```
 
 Or install via the command line:
@@ -185,6 +186,13 @@ The native decoders may support additional formats. You can always call `convert
 | Android | API 24 |
 | Windows | 7+ |
 | Linux | GStreamer 1.0+ |
+| Web | Modern browser with Web Audio API |
+
+### Web limitations
+
+- **File-based methods** (`convertToWav`, `convertToM4a`, `getAudioInfo`, `trimAudio`, `getWaveform`) are not available on web. Use the bytes-based API instead.
+- **M4A encoding** is not supported on web — browsers do not provide a reliable AAC/M4A encoding API. Use `convertToWavBytes` instead.
+- **Trimming** output is always WAV on web.
 
 ## License
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -95,6 +95,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   fuchsia_remote_debug_protocol:
     dependency: transitive
     description: flutter
@@ -270,6 +275,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.0.2"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   webdriver:
     dependency: transitive
     description:

--- a/lib/audio_conversion_exception.dart
+++ b/lib/audio_conversion_exception.dart
@@ -1,7 +1,16 @@
+/// Exception thrown when an audio conversion or analysis operation fails.
+///
+/// Contains a human-readable [message] and optional [details] from the
+/// native platform.
 class AudioConversionException implements Exception {
+  /// A human-readable description of the error.
   final String message;
+
+  /// Optional platform-specific details about the failure.
   final String? details;
 
+  /// Creates an [AudioConversionException] with the given [message] and
+  /// optional [details].
   AudioConversionException(this.message, {this.details});
 
   @override

--- a/lib/audio_decoder.dart
+++ b/lib/audio_decoder.dart
@@ -6,6 +6,10 @@ import 'audio_info.dart';
 export 'audio_conversion_exception.dart';
 export 'audio_info.dart';
 
+/// A lightweight audio decoder and converter using native platform APIs.
+///
+/// Provides static methods for converting, trimming, analyzing, and extracting
+/// waveform data from audio files and in-memory audio bytes.
 class AudioDecoder {
   /// Converts an audio file (MP3, M4A, AAC, etc.) to WAV format.
   ///

--- a/lib/audio_decoder_method_channel.dart
+++ b/lib/audio_decoder_method_channel.dart
@@ -5,6 +5,8 @@ import 'audio_conversion_exception.dart';
 import 'audio_decoder_platform_interface.dart';
 import 'audio_info.dart';
 
+/// Platform implementation of audio_decoder that uses a method channel to
+/// communicate with native platform code.
 class MethodChannelAudioDecoder extends AudioDecoderPlatform {
   @visibleForTesting
   final methodChannel = const MethodChannel('audio_decoder');

--- a/lib/audio_decoder_platform_interface.dart
+++ b/lib/audio_decoder_platform_interface.dart
@@ -5,15 +5,23 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'audio_decoder_method_channel.dart';
 import 'audio_info.dart';
 
+/// The interface that platform-specific implementations of audio_decoder must
+/// implement.
+///
+/// Platform implementations should extend this class rather than implement it,
+/// as new methods may be added in the future.
 abstract class AudioDecoderPlatform extends PlatformInterface {
+  /// Constructs an [AudioDecoderPlatform].
   AudioDecoderPlatform() : super(token: _token);
 
   static final Object _token = Object();
 
   static AudioDecoderPlatform _instance = MethodChannelAudioDecoder();
 
+  /// The current platform-specific implementation.
   static AudioDecoderPlatform get instance => _instance;
 
+  /// Sets the platform-specific implementation to use.
   static set instance(AudioDecoderPlatform instance) {
     PlatformInterface.verifyToken(instance, _token);
     _instance = instance;

--- a/lib/audio_decoder_web.dart
+++ b/lib/audio_decoder_web.dart
@@ -1,0 +1,257 @@
+import 'dart:js_interop';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+import 'package:web/web.dart' as web;
+
+import 'audio_conversion_exception.dart';
+import 'audio_decoder_platform_interface.dart';
+import 'audio_info.dart';
+
+/// Web platform implementation of audio_decoder using the Web Audio API.
+///
+/// File-based methods are not supported and throw [UnsupportedError].
+/// Use the bytes-based API instead.
+class AudioDecoderWeb extends AudioDecoderPlatform {
+  /// Creates an [AudioDecoderWeb] instance.
+  AudioDecoderWeb();
+
+  /// Registers this implementation as the web platform instance.
+  static void registerWith(Registrar registrar) {
+    AudioDecoderPlatform.instance = AudioDecoderWeb();
+  }
+
+  // --- File-based methods (not supported on web) ---
+
+  @override
+  Future<String> convertToWav(String inputPath, String outputPath) {
+    throw UnsupportedError(
+        'File-based operations are not supported on web. Use convertToWavBytes instead.');
+  }
+
+  @override
+  Future<String> convertToM4a(String inputPath, String outputPath) {
+    throw UnsupportedError(
+        'File-based operations are not supported on web. Use convertToM4aBytes instead.');
+  }
+
+  @override
+  Future<AudioInfo> getAudioInfo(String path) {
+    throw UnsupportedError(
+        'File-based operations are not supported on web. Use getAudioInfoBytes instead.');
+  }
+
+  @override
+  Future<String> trimAudio(
+      String inputPath, String outputPath, Duration start, Duration end) {
+    throw UnsupportedError(
+        'File-based operations are not supported on web. Use trimAudioBytes instead.');
+  }
+
+  @override
+  Future<List<double>> getWaveform(String path, int numberOfSamples) {
+    throw UnsupportedError(
+        'File-based operations are not supported on web. Use getWaveformBytes instead.');
+  }
+
+  // --- Bytes-based methods (Web Audio API) ---
+
+  Future<web.AudioBuffer> _decodeAudioData(Uint8List inputData) async {
+    final context = web.AudioContext();
+    try {
+      // Copy data since decodeAudioData detaches the ArrayBuffer
+      final copy = Uint8List.fromList(inputData);
+      return await context.decodeAudioData(copy.buffer.toJS).toDart;
+    } catch (e) {
+      if (e is AudioConversionException) rethrow;
+      throw AudioConversionException('Failed to decode audio data: $e');
+    } finally {
+      context.close();
+    }
+  }
+
+  Uint8List _encodeWav(web.AudioBuffer buffer,
+      {int? startSample, int? endSample}) {
+    final sampleRate = buffer.sampleRate.toInt();
+    final numChannels = buffer.numberOfChannels;
+    final start = startSample ?? 0;
+    final end = endSample ?? buffer.length;
+    final numFrames = end - start;
+    const bitsPerSample = 16;
+    final blockAlign = numChannels * bitsPerSample ~/ 8;
+    final dataSize = numFrames * blockAlign;
+    final fileSize = 44 + dataSize;
+
+    final channels = <Float32List>[];
+    for (var ch = 0; ch < numChannels; ch++) {
+      final full = buffer.getChannelData(ch).toDart;
+      channels.add(full.sublist(start, end));
+    }
+
+    final data = ByteData(fileSize);
+    var pos = 0;
+
+    void writeString(String s) {
+      for (var i = 0; i < s.length; i++) {
+        data.setUint8(pos++, s.codeUnitAt(i));
+      }
+    }
+
+    // RIFF header
+    writeString('RIFF');
+    data.setUint32(pos, 36 + dataSize, Endian.little);
+    pos += 4;
+    writeString('WAVE');
+
+    // fmt chunk
+    writeString('fmt ');
+    data.setUint32(pos, 16, Endian.little);
+    pos += 4;
+    data.setUint16(pos, 1, Endian.little);
+    pos += 2; // PCM
+    data.setUint16(pos, numChannels, Endian.little);
+    pos += 2;
+    data.setUint32(pos, sampleRate, Endian.little);
+    pos += 4;
+    data.setUint32(pos, sampleRate * blockAlign, Endian.little);
+    pos += 4;
+    data.setUint16(pos, blockAlign, Endian.little);
+    pos += 2;
+    data.setUint16(pos, bitsPerSample, Endian.little);
+    pos += 2;
+
+    // data chunk
+    writeString('data');
+    data.setUint32(pos, dataSize, Endian.little);
+    pos += 4;
+
+    // Interleaved PCM samples
+    for (var i = 0; i < numFrames; i++) {
+      for (var ch = 0; ch < numChannels; ch++) {
+        final sample =
+            (channels[ch][i] * 32767).round().clamp(-32768, 32767);
+        data.setInt16(pos, sample, Endian.little);
+        pos += 2;
+      }
+    }
+
+    return data.buffer.asUint8List();
+  }
+
+  @override
+  Future<Uint8List> convertToWavBytes(
+      Uint8List inputData, String formatHint) async {
+    try {
+      final buffer = await _decodeAudioData(inputData);
+      return _encodeWav(buffer);
+    } catch (e) {
+      if (e is AudioConversionException) rethrow;
+      throw AudioConversionException('WAV conversion failed: $e');
+    }
+  }
+
+  @override
+  Future<Uint8List> convertToM4aBytes(
+      Uint8List inputData, String formatHint) async {
+    throw AudioConversionException(
+      'M4A encoding is not supported on web',
+      details:
+          'Browsers do not provide a reliable AAC/M4A encoding API. Use convertToWavBytes instead.',
+    );
+  }
+
+  @override
+  Future<AudioInfo> getAudioInfoBytes(
+      Uint8List inputData, String formatHint) async {
+    try {
+      final buffer = await _decodeAudioData(inputData);
+      final durationMs = (buffer.duration * 1000).round();
+      final sampleRate = buffer.sampleRate.toInt();
+      final channels = buffer.numberOfChannels;
+      final bitRate = buffer.duration > 0
+          ? ((inputData.length * 8) / buffer.duration).round()
+          : 0;
+      return AudioInfo(
+        duration: Duration(milliseconds: durationMs),
+        sampleRate: sampleRate,
+        channels: channels,
+        bitRate: bitRate,
+        format: formatHint,
+      );
+    } catch (e) {
+      if (e is AudioConversionException) rethrow;
+      throw AudioConversionException('Failed to get audio info: $e');
+    }
+  }
+
+  @override
+  Future<Uint8List> trimAudioBytes(Uint8List inputData, String formatHint,
+      Duration start, Duration end,
+      {String outputFormat = 'wav'}) async {
+    if (outputFormat == 'm4a') {
+      throw AudioConversionException(
+        'M4A encoding is not supported on web',
+        details: 'Use outputFormat: "wav" instead.',
+      );
+    }
+    try {
+      final buffer = await _decodeAudioData(inputData);
+      final sampleRate = buffer.sampleRate;
+      final startSample =
+          (start.inMilliseconds * sampleRate / 1000).round();
+      final endSample = min(
+          (end.inMilliseconds * sampleRate / 1000).round(), buffer.length);
+      return _encodeWav(buffer,
+          startSample: startSample, endSample: endSample);
+    } catch (e) {
+      if (e is AudioConversionException) rethrow;
+      throw AudioConversionException('Trim failed: $e');
+    }
+  }
+
+  @override
+  Future<List<double>> getWaveformBytes(
+      Uint8List inputData, String formatHint, int numberOfSamples) async {
+    try {
+      final buffer = await _decodeAudioData(inputData);
+      final channelData = buffer.getChannelData(0).toDart;
+      final totalSamples = channelData.length;
+
+      if (totalSamples == 0) {
+        return List.filled(numberOfSamples, 0.0);
+      }
+
+      final samplesPerWindow = max(1, totalSamples ~/ numberOfSamples);
+      final waveform = <double>[];
+      var maxRms = 0.0;
+
+      for (var i = 0; i < numberOfSamples; i++) {
+        final start = i * totalSamples ~/ numberOfSamples;
+        final end = min(start + samplesPerWindow, totalSamples);
+        if (start >= totalSamples) break;
+
+        var sumSquares = 0.0;
+        for (var j = start; j < end; j++) {
+          final s = channelData[j];
+          sumSquares += s * s;
+        }
+        final rms = sqrt(sumSquares / (end - start));
+        waveform.add(rms);
+        if (rms > maxRms) maxRms = rms;
+      }
+
+      final result =
+          waveform.map((rms) => maxRms > 0 ? rms / maxRms : 0.0).toList();
+
+      while (result.length < numberOfSamples) {
+        result.add(0.0);
+      }
+
+      return result;
+    } catch (e) {
+      if (e is AudioConversionException) rethrow;
+      throw AudioConversionException('Waveform extraction failed: $e');
+    }
+  }
+}

--- a/lib/audio_info.dart
+++ b/lib/audio_info.dart
@@ -1,10 +1,23 @@
+/// Metadata about an audio file or audio data.
+///
+/// Returned by [AudioDecoder.getAudioInfo] and [AudioDecoder.getAudioInfoBytes].
 class AudioInfo {
+  /// Total duration of the audio.
   final Duration duration;
+
+  /// Sample rate in Hz (e.g., 44100, 48000).
   final int sampleRate;
+
+  /// Number of audio channels (1 = mono, 2 = stereo).
   final int channels;
+
+  /// Bit rate in bits per second (e.g., 128000 for 128 kbps).
   final int bitRate;
+
+  /// Audio format identifier (e.g., 'mp3', 'm4a', 'wav').
   final String format;
 
+  /// Creates an [AudioInfo] with the given metadata.
   const AudioInfo({
     required this.duration,
     required this.sampleRate,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_decoder
 description: "A lightweight Flutter plugin for converting, trimming, and analyzing audio files using native platform APIs. No FFmpeg required."
-version: 0.3.0
+version: 0.4.0
 homepage: https://www.silversoft.nl
 repository: https://github.com/sjoenk/audio_decoder
 
@@ -11,7 +11,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_web_plugins:
+    sdk: flutter
   plugin_platform_interface: ^2.0.2
+  web: ^1.1.0
 
 dev_dependencies:
   flutter_test:
@@ -46,6 +49,9 @@ flutter:
         pluginClass: AudioDecoderPlugin
       windows:
         pluginClass: AudioDecoderPluginCApi
+      web:
+        pluginClass: AudioDecoderWeb
+        fileName: audio_decoder_web.dart
 
   # To add assets to your plugin package, add an assets section, like this:
   # assets:


### PR DESCRIPTION
## Summary

- Add web platform implementation using the Web Audio API
- Bytes-based methods (`convertToWavBytes`, `getAudioInfoBytes`, `trimAudioBytes`, `getWaveformBytes`) are fully supported
- File-based methods throw `UnsupportedError` on web — use the bytes API instead
- M4A encoding is not available on web (browser limitation)
- Add API documentation comments to all public API elements
- Update README with web platform, limitations, and requirements
- Bump version to 0.4.0

## Web limitations

- No file-based methods (no filesystem access in browsers)
- No M4A/AAC encoding (no browser encoding API)
- Trim output is always WAV

## Test plan

- [x] `flutter test` — 32/32 passing
- [x] `dart analyze` — no issues
- [x] Manual test in Chrome with example app

🤖 Generated with [Claude Code](https://claude.com/claude-code)