### PR TITLE
Add optional WAV conversion parameters (sampleRate, channels, bitDepth)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.5.0
+
+* Add optional `sampleRate`, `channels`, and `bitDepth` parameters to `convertToWav` and `convertToWavBytes`.
+* Control output sample rate (e.g., 44100, 22050), channel count (1 for mono, 2 for stereo), and bit depth (8, 16, 24, 32).
+* When omitted, defaults to the source sample rate/channels and 16-bit depth.
+* Supported on all platforms: Android, iOS, macOS, Windows, Linux, and Web.
+
 ## 0.4.0
 
 * Add web support using the Web Audio API.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add `audio_decoder` to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  audio_decoder: ^0.4.0
+  audio_decoder: ^0.5.0
 ```
 
 Or install via the command line:
@@ -59,6 +59,15 @@ import 'package:audio_decoder/audio_decoder.dart';
 final wavPath = await AudioDecoder.convertToWav(
   '/path/to/song.mp3',
   '/path/to/output.wav',
+);
+
+// Convert to WAV with custom encoding
+final wavPath2 = await AudioDecoder.convertToWav(
+  '/path/to/song.mp3',
+  '/path/to/output.wav',
+  sampleRate: 44100,  // optional: target sample rate
+  channels: 1,        // optional: 1 = mono, 2 = stereo
+  bitDepth: 24,       // optional: 8, 16, 24, or 32
 );
 
 // Convert to M4A (AAC compressed)
@@ -123,6 +132,15 @@ final wavBytes = await AudioDecoder.convertToWavBytes(
   formatHint: 'mp3',
 );
 
+// Convert bytes to WAV with custom encoding
+final wavBytes2 = await AudioDecoder.convertToWavBytes(
+  mp3Bytes,
+  formatHint: 'mp3',
+  sampleRate: 22050,
+  channels: 1,
+  bitDepth: 16,
+);
+
 // Get metadata from bytes
 final info = await AudioDecoder.getAudioInfoBytes(
   mp3Bytes,
@@ -168,8 +186,8 @@ The native decoders may support additional formats. You can always call `convert
 ## Output formats
 
 ### WAV
-- PCM signed 16-bit little-endian
-- Original sample rate and channel count preserved
+- PCM signed little-endian (16-bit by default, configurable to 8, 24, or 32-bit)
+- Sample rate and channel count default to source values, optionally overridable
 - Standard 44-byte RIFF/WAVE header
 
 ### M4A

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -1,0 +1,22 @@
+PODS:
+  - audio_decoder (0.0.1):
+    - FlutterMacOS
+  - FlutterMacOS (1.0.0)
+
+DEPENDENCIES:
+  - audio_decoder (from `Flutter/ephemeral/.symlinks/plugins/audio_decoder/macos`)
+  - FlutterMacOS (from `Flutter/ephemeral`)
+
+EXTERNAL SOURCES:
+  audio_decoder:
+    :path: Flutter/ephemeral/.symlinks/plugins/audio_decoder/macos
+  FlutterMacOS:
+    :path: Flutter/ephemeral
+
+SPEC CHECKSUMS:
+  audio_decoder: 6c511123c2f9986764a05673f7c51ad8504dfc7e
+  FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+
+PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
+
+COCOAPODS: 1.16.2

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		7D3598F41317F0A10CE791EA /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 703C884D17CDF65C0C864024 /* Pods_Runner.framework */; };
+		B5B9C25EE30F765429B5FE97 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 309A53065C7B936CE2F864B5 /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,11 +62,13 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0933181ABCADC0B33D7D228F /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		309A53065C7B936CE2F864B5 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D5294CF71000263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* audio_decoder_example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "audio_decoder_example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* audio_decoder_example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = audio_decoder_example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -76,8 +80,14 @@
 		33E51913231747F40026EE4D /* DebugProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DebugProfile.entitlements; sourceTree = "<group>"; };
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
+		463C9DE14C6FCF0BF688BB20 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		5D3A6DD194D4A6C140F1FCB0 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		703C884D17CDF65C0C864024 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		8982A86C6438C1B26617820D /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		AE5FE7250760DDDF39CD0CAD /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		F4F4CCFDE89AF2598A5A526D /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B5B9C25EE30F765429B5FE97 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -92,6 +103,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7D3598F41317F0A10CE791EA /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -125,6 +137,7 @@
 				331C80D6294CF71000263BE5 /* RunnerTests */,
 				33CC10EE2044A3C60003C045 /* Products */,
 				D73912EC22F37F3D000D13A0 /* Frameworks */,
+				9CA175491AB7AA456DCC8DE7 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -172,9 +185,25 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		9CA175491AB7AA456DCC8DE7 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				8982A86C6438C1B26617820D /* Pods-Runner.debug.xcconfig */,
+				0933181ABCADC0B33D7D228F /* Pods-Runner.release.xcconfig */,
+				AE5FE7250760DDDF39CD0CAD /* Pods-Runner.profile.xcconfig */,
+				5D3A6DD194D4A6C140F1FCB0 /* Pods-RunnerTests.debug.xcconfig */,
+				463C9DE14C6FCF0BF688BB20 /* Pods-RunnerTests.release.xcconfig */,
+				F4F4CCFDE89AF2598A5A526D /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				703C884D17CDF65C0C864024 /* Pods_Runner.framework */,
+				309A53065C7B936CE2F864B5 /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -186,6 +215,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C80DE294CF71000263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				EC193E7839EFA6CFC79F795F /* [CP] Check Pods Manifest.lock */,
 				331C80D1294CF70F00263BE5 /* Sources */,
 				331C80D2294CF70F00263BE5 /* Frameworks */,
 				331C80D3294CF70F00263BE5 /* Resources */,
@@ -204,11 +234,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				111117D421BB8A5C338A4297 /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				DF4882B23B53E20B9F936E09 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -291,6 +323,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		111117D421BB8A5C338A4297 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -328,6 +382,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
+		};
+		DF4882B23B53E20B9F936E09 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		EC193E7839EFA6CFC79F795F /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -380,6 +473,7 @@
 /* Begin XCBuildConfiguration section */
 		331C80DB294CF71000263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5D3A6DD194D4A6C140F1FCB0 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -394,6 +488,7 @@
 		};
 		331C80DC294CF71000263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 463C9DE14C6FCF0BF688BB20 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -408,6 +503,7 @@
 		};
 		331C80DD294CF71000263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F4F4CCFDE89AF2598A5A526D /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;

--- a/example/macos/Runner.xcworkspace/contents.xcworkspacedata
+++ b/example/macos/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -15,7 +15,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.4.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/lib/audio_decoder.dart
+++ b/lib/audio_decoder.dart
@@ -15,11 +15,20 @@ class AudioDecoder {
   ///
   /// [inputPath] is the absolute path to the source audio file.
   /// [outputPath] is the absolute path where the WAV file will be written.
+  /// [sampleRate] optionally sets the output sample rate (e.g., 44100). Defaults to source sample rate.
+  /// [channels] optionally sets the number of output channels (e.g., 1 for mono, 2 for stereo). Defaults to source channels.
+  /// [bitDepth] optionally sets the output bit depth (e.g., 16, 24). Defaults to 16.
   ///
   /// Returns the output path on success.
   /// Throws [AudioConversionException] on failure.
-  static Future<String> convertToWav(String inputPath, String outputPath) {
-    return AudioDecoderPlatform.instance.convertToWav(inputPath, outputPath);
+  static Future<String> convertToWav(
+    String inputPath,
+    String outputPath, {
+    int? sampleRate,
+    int? channels,
+    int? bitDepth,
+  }) {
+    return AudioDecoderPlatform.instance.convertToWav(inputPath, outputPath, sampleRate: sampleRate, channels: channels, bitDepth: bitDepth);
   }
 
   /// Converts an audio file (MP3, WAV, FLAC, etc.) to M4A (AAC) format.
@@ -112,11 +121,20 @@ class AudioDecoder {
   ///
   /// [inputData] is the raw bytes of the source audio file.
   /// [formatHint] indicates the input format (e.g., 'mp3', 'm4a', 'aac').
+  /// [sampleRate] optionally sets the output sample rate (e.g., 44100). Defaults to source sample rate.
+  /// [channels] optionally sets the number of output channels (e.g., 1 for mono, 2 for stereo). Defaults to source channels.
+  /// [bitDepth] optionally sets the output bit depth (e.g., 16, 24). Defaults to 16.
   ///
   /// Returns the WAV file bytes.
   /// Throws [AudioConversionException] on failure.
-  static Future<Uint8List> convertToWavBytes(Uint8List inputData, {required String formatHint}) {
-    return AudioDecoderPlatform.instance.convertToWavBytes(inputData, formatHint);
+  static Future<Uint8List> convertToWavBytes(
+    Uint8List inputData, {
+    required String formatHint,
+    int? sampleRate,
+    int? channels,
+    int? bitDepth,
+  }) {
+    return AudioDecoderPlatform.instance.convertToWavBytes(inputData, formatHint, sampleRate: sampleRate, channels: channels, bitDepth: bitDepth);
   }
 
   /// Converts audio bytes to M4A (AAC) format.

--- a/lib/audio_decoder_method_channel.dart
+++ b/lib/audio_decoder_method_channel.dart
@@ -12,11 +12,18 @@ class MethodChannelAudioDecoder extends AudioDecoderPlatform {
   final methodChannel = const MethodChannel('audio_decoder');
 
   @override
-  Future<String> convertToWav(String inputPath, String outputPath) async {
+  Future<String> convertToWav(String inputPath, String outputPath, {int? sampleRate, int? channels, int? bitDepth}) async {
     try {
+      final args = <String, dynamic>{
+        'inputPath': inputPath,
+        'outputPath': outputPath,
+      };
+      if (sampleRate != null) args['sampleRate'] = sampleRate;
+      if (channels != null) args['channels'] = channels;
+      if (bitDepth != null) args['bitDepth'] = bitDepth;
       final result = await methodChannel.invokeMethod<String>(
         'convertToWav',
-        {'inputPath': inputPath, 'outputPath': outputPath},
+        args,
       );
       if (result == null) {
         throw AudioConversionException('Native conversion returned null');
@@ -118,11 +125,18 @@ class MethodChannelAudioDecoder extends AudioDecoderPlatform {
   }
 
   @override
-  Future<Uint8List> convertToWavBytes(Uint8List inputData, String formatHint) async {
+  Future<Uint8List> convertToWavBytes(Uint8List inputData, String formatHint, {int? sampleRate, int? channels, int? bitDepth}) async {
     try {
+      final args = <String, dynamic>{
+        'inputData': inputData,
+        'formatHint': formatHint,
+      };
+      if (sampleRate != null) args['sampleRate'] = sampleRate;
+      if (channels != null) args['channels'] = channels;
+      if (bitDepth != null) args['bitDepth'] = bitDepth;
       final result = await methodChannel.invokeMethod<Uint8List>(
         'convertToWavBytes',
-        {'inputData': inputData, 'formatHint': formatHint},
+        args,
       );
       if (result == null) {
         throw AudioConversionException('Native conversion returned null');

--- a/lib/audio_decoder_platform_interface.dart
+++ b/lib/audio_decoder_platform_interface.dart
@@ -27,7 +27,7 @@ abstract class AudioDecoderPlatform extends PlatformInterface {
     _instance = instance;
   }
 
-  Future<String> convertToWav(String inputPath, String outputPath) {
+  Future<String> convertToWav(String inputPath, String outputPath, {int? sampleRate, int? channels, int? bitDepth}) {
     throw UnimplementedError('convertToWav() has not been implemented.');
   }
 
@@ -47,7 +47,7 @@ abstract class AudioDecoderPlatform extends PlatformInterface {
     throw UnimplementedError('getWaveform() has not been implemented.');
   }
 
-  Future<Uint8List> convertToWavBytes(Uint8List inputData, String formatHint) {
+  Future<Uint8List> convertToWavBytes(Uint8List inputData, String formatHint, {int? sampleRate, int? channels, int? bitDepth}) {
     throw UnimplementedError('convertToWavBytes() has not been implemented.');
   }
 

--- a/macos/Classes/AudioDecoderPlugin.swift
+++ b/macos/Classes/AudioDecoderPlugin.swift
@@ -15,9 +15,9 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
         case "convertToWav":
-            guard let args = call.arguments as? [String: String],
-                  let inputPath = args["inputPath"],
-                  let outputPath = args["outputPath"] else {
+            guard let args = call.arguments as? [String: Any],
+                  let inputPath = args["inputPath"] as? String,
+                  let outputPath = args["outputPath"] as? String else {
                 result(FlutterError(
                     code: "INVALID_ARGUMENTS",
                     message: "inputPath and outputPath are required",
@@ -25,7 +25,10 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
                 ))
                 return
             }
-            convertToWav(inputPath: inputPath, outputPath: outputPath, result: result)
+            let sampleRate = args["sampleRate"] as? Int
+            let channels = args["channels"] as? Int
+            let bitDepth = args["bitDepth"] as? Int
+            convertToWav(inputPath: inputPath, outputPath: outputPath, sampleRate: sampleRate, channels: channels, bitDepth: bitDepth, result: result)
         case "convertToM4a":
             guard let args = call.arguments as? [String: String],
                   let inputPath = args["inputPath"],
@@ -82,7 +85,10 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
                 result(FlutterError(code: "INVALID_ARGUMENTS", message: "inputData and formatHint are required", details: nil))
                 return
             }
-            convertToWavBytes(inputData: inputData, formatHint: formatHint, result: result)
+            let sampleRate = args["sampleRate"] as? Int
+            let channels = args["channels"] as? Int
+            let bitDepth = args["bitDepth"] as? Int
+            convertToWavBytes(inputData: inputData, formatHint: formatHint, sampleRate: sampleRate, channels: channels, bitDepth: bitDepth, result: result)
         case "convertToM4aBytes":
             guard let args = call.arguments as? [String: Any],
                   let inputData = args["inputData"] as? FlutterStandardTypedData,
@@ -126,10 +132,10 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
 
     // MARK: - Convert to WAV
 
-    private func convertToWav(inputPath: String, outputPath: String, result: @escaping FlutterResult) {
+    private func convertToWav(inputPath: String, outputPath: String, sampleRate: Int?, channels: Int?, bitDepth: Int?, result: @escaping FlutterResult) {
         DispatchQueue.global(qos: .userInitiated).async {
             do {
-                try self.performConversion(inputPath: inputPath, outputPath: outputPath)
+                try self.performConversion(inputPath: inputPath, outputPath: outputPath, targetSampleRate: sampleRate, targetChannels: channels, targetBitDepth: bitDepth)
                 DispatchQueue.main.async {
                     result(outputPath)
                 }
@@ -145,7 +151,7 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    private func performConversion(inputPath: String, outputPath: String) throws {
+    private func performConversion(inputPath: String, outputPath: String, targetSampleRate: Int? = nil, targetChannels: Int? = nil, targetBitDepth: Int? = nil) throws {
         let inputURL = URL(fileURLWithPath: inputPath)
         let outputURL = URL(fileURLWithPath: outputPath)
 
@@ -166,13 +172,21 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
                           userInfo: [NSLocalizedDescriptionKey: "No audio track found in \(inputPath)"])
         }
 
-        let outputSettings: [String: Any] = [
+        let bitsPerSample = targetBitDepth ?? 16
+
+        var outputSettings: [String: Any] = [
             AVFormatIDKey: kAudioFormatLinearPCM,
-            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMBitDepthKey: bitsPerSample,
             AVLinearPCMIsFloatKey: false,
             AVLinearPCMIsBigEndianKey: false,
             AVLinearPCMIsNonInterleaved: false,
         ]
+        if let sr = targetSampleRate {
+            outputSettings[AVSampleRateKey] = sr
+        }
+        if let ch = targetChannels {
+            outputSettings[AVNumberOfChannelsKey] = ch
+        }
 
         let trackOutput = AVAssetReaderTrackOutput(track: audioTrack, outputSettings: outputSettings)
         trackOutput.alwaysCopiesSampleData = false
@@ -212,11 +226,11 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
             formatDesc as! CMAudioFormatDescription
         )!.pointee
 
-        let sampleRate = Int(asbd.mSampleRate)
-        let channels = Int(asbd.mChannelsPerFrame)
+        let sampleRate = targetSampleRate ?? Int(asbd.mSampleRate)
+        let channels = targetChannels ?? Int(asbd.mChannelsPerFrame)
 
         try writeWavFile(outputURL: outputURL, pcmData: pcmData,
-                         sampleRate: sampleRate, channels: channels, bitsPerSample: 16)
+                         sampleRate: sampleRate, channels: channels, bitsPerSample: bitsPerSample)
     }
 
     // MARK: - Convert to M4A
@@ -602,7 +616,7 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
 
     // MARK: - Bytes-based methods
 
-    private func convertToWavBytes(inputData: FlutterStandardTypedData, formatHint: String, result: @escaping FlutterResult) {
+    private func convertToWavBytes(inputData: FlutterStandardTypedData, formatHint: String, sampleRate: Int?, channels: Int?, bitDepth: Int?, result: @escaping FlutterResult) {
         DispatchQueue.global(qos: .userInitiated).async {
             do {
                 let tempInputURL = try self.writeTempInput(data: inputData, formatHint: formatHint)
@@ -611,7 +625,7 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
                     try? FileManager.default.removeItem(at: tempInputURL)
                     try? FileManager.default.removeItem(at: tempOutputURL)
                 }
-                try self.performConversion(inputPath: tempInputURL.path, outputPath: tempOutputURL.path)
+                try self.performConversion(inputPath: tempInputURL.path, outputPath: tempOutputURL.path, targetSampleRate: sampleRate, targetChannels: channels, targetBitDepth: bitDepth)
                 let outputData = try Data(contentsOf: tempOutputURL)
                 DispatchQueue.main.async {
                     result(FlutterStandardTypedData(bytes: outputData))

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_decoder
 description: "A lightweight Flutter plugin for converting, trimming, and analyzing audio files using native platform APIs. No FFmpeg required."
-version: 0.4.0
+version: 0.5.0
 homepage: https://www.silversoft.nl
 repository: https://github.com/sjoenk/audio_decoder
 

--- a/test/audio_decoder_method_channel_test.dart
+++ b/test/audio_decoder_method_channel_test.dart
@@ -18,10 +18,45 @@ void main() {
       MethodCall methodCall,
     ) async {
       expect(methodCall.method, 'convertToWav');
-      expect(methodCall.arguments, {
-        'inputPath': '/input/test.mp3',
-        'outputPath': '/output/test.wav',
-      });
+      expect(methodCall.arguments['inputPath'], '/input/test.mp3');
+      expect(methodCall.arguments['outputPath'], '/output/test.wav');
+      return '/output/test.wav';
+    });
+
+    expect(
+      await platform.convertToWav('/input/test.mp3', '/output/test.wav'),
+      '/output/test.wav',
+    );
+  });
+
+  test('convertToWav sends optional parameters when provided', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, (
+      MethodCall methodCall,
+    ) async {
+      expect(methodCall.method, 'convertToWav');
+      expect(methodCall.arguments['inputPath'], '/input/test.mp3');
+      expect(methodCall.arguments['outputPath'], '/output/test.wav');
+      expect(methodCall.arguments['sampleRate'], 44100);
+      expect(methodCall.arguments['channels'], 1);
+      expect(methodCall.arguments['bitDepth'], 24);
+      return '/output/test.wav';
+    });
+
+    expect(
+      await platform.convertToWav('/input/test.mp3', '/output/test.wav',
+          sampleRate: 44100, channels: 1, bitDepth: 24),
+      '/output/test.wav',
+    );
+  });
+
+  test('convertToWav omits null optional parameters', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, (
+      MethodCall methodCall,
+    ) async {
+      expect(methodCall.method, 'convertToWav');
+      expect(methodCall.arguments.containsKey('sampleRate'), false);
+      expect(methodCall.arguments.containsKey('channels'), false);
+      expect(methodCall.arguments.containsKey('bitDepth'), false);
       return '/output/test.wav';
     });
 
@@ -277,6 +312,23 @@ void main() {
         () => platform.convertToWavBytes(testInput, 'mp3'),
         throwsA(isA<AudioConversionException>()),
       );
+    });
+
+    test('convertToWavBytes sends optional parameters when provided', () async {
+      final wavBytes = Uint8List.fromList([0x52, 0x49, 0x46, 0x46]);
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, (
+        MethodCall methodCall,
+      ) async {
+        expect(methodCall.method, 'convertToWavBytes');
+        expect(methodCall.arguments['sampleRate'], 22050);
+        expect(methodCall.arguments['channels'], 1);
+        expect(methodCall.arguments['bitDepth'], 8);
+        return wavBytes;
+      });
+
+      final result = await platform.convertToWavBytes(testInput, 'mp3',
+          sampleRate: 22050, channels: 1, bitDepth: 8);
+      expect(result, wavBytes);
     });
   });
 }

--- a/test/audio_decoder_test.dart
+++ b/test/audio_decoder_test.dart
@@ -8,7 +8,7 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 class MockAudioDecoderPlatform with MockPlatformInterfaceMixin implements AudioDecoderPlatform {
   @override
-  Future<String> convertToWav(String inputPath, String outputPath) => Future.value(outputPath);
+  Future<String> convertToWav(String inputPath, String outputPath, {int? sampleRate, int? channels, int? bitDepth}) => Future.value(outputPath);
 
   @override
   Future<String> convertToM4a(String inputPath, String outputPath) => Future.value(outputPath);
@@ -32,7 +32,7 @@ class MockAudioDecoderPlatform with MockPlatformInterfaceMixin implements AudioD
   Future<List<double>> getWaveform(String path, int numberOfSamples) => Future.value(List.filled(numberOfSamples, 0.5));
 
   @override
-  Future<Uint8List> convertToWavBytes(Uint8List inputData, String formatHint) =>
+  Future<Uint8List> convertToWavBytes(Uint8List inputData, String formatHint, {int? sampleRate, int? channels, int? bitDepth}) =>
       Future.value(Uint8List.fromList([0x52, 0x49, 0x46, 0x46])); // RIFF header stub
 
   @override
@@ -209,6 +209,51 @@ void main() {
       );
       expect(waveform.length, 30);
       expect(waveform.first, 0.7);
+    });
+  });
+
+  group('convertToWav with optional parameters', () {
+    late MockAudioDecoderPlatform fakePlatform;
+
+    setUp(() {
+      fakePlatform = MockAudioDecoderPlatform();
+      AudioDecoderPlatform.instance = fakePlatform;
+    });
+
+    test('convertToWav accepts sampleRate parameter', () async {
+      expect(
+        await AudioDecoder.convertToWav('/input/test.mp3', '/output/test.wav', sampleRate: 44100),
+        '/output/test.wav',
+      );
+    });
+
+    test('convertToWav accepts channels parameter', () async {
+      expect(
+        await AudioDecoder.convertToWav('/input/test.mp3', '/output/test.wav', channels: 1),
+        '/output/test.wav',
+      );
+    });
+
+    test('convertToWav accepts bitDepth parameter', () async {
+      expect(
+        await AudioDecoder.convertToWav('/input/test.mp3', '/output/test.wav', bitDepth: 24),
+        '/output/test.wav',
+      );
+    });
+
+    test('convertToWav accepts all parameters', () async {
+      expect(
+        await AudioDecoder.convertToWav('/input/test.mp3', '/output/test.wav',
+            sampleRate: 48000, channels: 2, bitDepth: 16),
+        '/output/test.wav',
+      );
+    });
+
+    test('convertToWavBytes accepts optional parameters', () async {
+      final input = Uint8List.fromList([1, 2, 3]);
+      final result = await AudioDecoder.convertToWavBytes(input,
+          formatHint: 'mp3', sampleRate: 22050, channels: 1, bitDepth: 8);
+      expect(result, isNotEmpty);
     });
   });
 }

--- a/windows/audio_decoder_plugin.h
+++ b/windows/audio_decoder_plugin.h
@@ -27,7 +27,10 @@ class AudioDecoderPlugin : public flutter::Plugin {
 
  private:
   std::string ConvertToWav(const std::string& inputPath,
-                           const std::string& outputPath);
+                           const std::string& outputPath,
+                           int targetSampleRate = -1,
+                           int targetChannels = -1,
+                           int targetBitDepth = -1);
   std::string ConvertToM4a(const std::string& inputPath,
                            const std::string& outputPath);
   flutter::EncodableMap GetAudioInfo(const std::string& path);
@@ -47,7 +50,10 @@ class AudioDecoderPlugin : public flutter::Plugin {
       uint32_t bitsPerSample;
   };
   PcmResult DecodeToPcm(const std::string& inputPath,
-                         int64_t startMs = -1, int64_t endMs = -1);
+                         int64_t startMs = -1, int64_t endMs = -1,
+                         int targetSampleRate = -1,
+                         int targetChannels = -1,
+                         int targetBitDepth = -1);
 
   // Temp file helpers for bytes-based API
   std::string WriteTempFile(const std::vector<uint8_t>& data,


### PR DESCRIPTION
## Summary
- Add optional `sampleRate`, `channels`, and `bitDepth` parameters to `convertToWav` and `convertToWavBytes` across all platforms (iOS, macOS, Android, Windows, Linux, Web)
- Enables full control over WAV output encoding — replaces the need for `ffmpeg_kit` in audio conversion workflows
- Bump version to 0.5.0 with updated changelog, readme, and API documentation

## Implementation per platform
| Platform | Approach |
|----------|----------|
| iOS/macOS | AVAssetReader output settings (`AVSampleRateKey`, `AVNumberOfChannelsKey`, `AVLinearPCMBitDepthKey`) |
| Android | Manual PCM resampling (linear interpolation), channel conversion, bit depth conversion |
| Windows | Media Foundation `IMFMediaType` attributes |
| Linux | GStreamer capsfilter with `format`, `rate`, `channels` |
| Web | `OfflineAudioContext` for resampling, manual channel mixing and multi-bit-depth encoding |

## Test plan
- [x] All 40 Flutter unit tests pass (8 new tests added)
- [x] macOS example app builds successfully
- [ ] Manual test on Android device
- [ ] Manual test on Windows
- [ ] Manual test on Linux

Closes #4