### PR TITLE
Add raw PCM output option (headerless WAV)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.6.0
+
+* Add `includeHeader` parameter to `convertToWavBytes` (default `true`).
+* When `false`, returns only raw interleaved PCM data without the 44-byte RIFF/WAV header.
+* Useful for real-time audio pipelines, direct hardware interfaces, and custom audio processing.
+* Supported on all platforms: Android, iOS, macOS, Windows, Linux, and Web.
+
 ## 0.5.0
 
 * Add optional `sampleRate`, `channels`, and `bitDepth` parameters to `convertToWav` and `convertToWavBytes`.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add `audio_decoder` to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  audio_decoder: ^0.5.0
+  audio_decoder: ^0.6.0
 ```
 
 Or install via the command line:
@@ -141,6 +141,13 @@ final wavBytes2 = await AudioDecoder.convertToWavBytes(
   bitDepth: 16,
 );
 
+// Get raw PCM bytes (no WAV header)
+final pcmBytes = await AudioDecoder.convertToWavBytes(
+  mp3Bytes,
+  formatHint: 'mp3',
+  includeHeader: false,  // returns raw interleaved PCM samples only
+);
+
 // Get metadata from bytes
 final info = await AudioDecoder.getAudioInfoBytes(
   mp3Bytes,
@@ -188,7 +195,7 @@ The native decoders may support additional formats. You can always call `convert
 ### WAV
 - PCM signed little-endian (16-bit by default, configurable to 8, 24, or 32-bit)
 - Sample rate and channel count default to source values, optionally overridable
-- Standard 44-byte RIFF/WAVE header
+- Standard 44-byte RIFF/WAVE header (can be omitted with `includeHeader: false` in `convertToWavBytes` for raw PCM output)
 
 ### M4A
 - AAC-LC encoding at 128 kbps

--- a/example/integration_test/plugin_integration_test.dart
+++ b/example/integration_test/plugin_integration_test.dart
@@ -6,6 +6,7 @@
 // For more information about Flutter integration tests, please see
 // https://flutter.dev/to/integration-testing
 
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -17,5 +18,28 @@ void main() {
   testWidgets('needsConversion test', (WidgetTester tester) async {
     expect(AudioDecoder.needsConversion('test.mp3'), true);
     expect(AudioDecoder.needsConversion('test.wav'), false);
+  });
+
+  testWidgets('convertToWavBytes with header returns valid WAV', (WidgetTester tester) async {
+    final mp3Bytes = (await rootBundle.load('assets/test_tone.mp3')).buffer.asUint8List();
+    final wavBytes = await AudioDecoder.convertToWavBytes(mp3Bytes, formatHint: 'mp3');
+
+    // Should start with RIFF header
+    expect(wavBytes.length, greaterThan(44));
+    expect(String.fromCharCodes(wavBytes.sublist(0, 4)), 'RIFF');
+    expect(String.fromCharCodes(wavBytes.sublist(8, 12)), 'WAVE');
+  });
+
+  testWidgets('convertToWavBytes without header returns raw PCM', (WidgetTester tester) async {
+    final mp3Bytes = (await rootBundle.load('assets/test_tone.mp3')).buffer.asUint8List();
+    final wavBytes = await AudioDecoder.convertToWavBytes(mp3Bytes, formatHint: 'mp3');
+    final pcmBytes = await AudioDecoder.convertToWavBytes(mp3Bytes, formatHint: 'mp3', includeHeader: false);
+
+    // PCM should be exactly 44 bytes smaller than the WAV version
+    expect(pcmBytes.length, wavBytes.length - 44);
+    // Should NOT start with RIFF
+    expect(String.fromCharCodes(pcmBytes.sublist(0, 4)), isNot('RIFF'));
+    // PCM data should match the WAV data after the header
+    expect(pcmBytes, wavBytes.sublist(44));
   });
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -365,127 +365,140 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       home: Scaffold(
         appBar: AppBar(title: const Text('Audio Decoder Example')),
-        body: SingleChildScrollView(
-          padding: const EdgeInsets.all(16.0),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Text(
-                _status,
-                textAlign: TextAlign.center,
-                style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+        body: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                children: [
+                  Text(
+                    _status,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+                  ),
+                  if (_waveform != null) ...[
+                    const SizedBox(height: 12),
+                    Container(
+                      height: 100,
+                      decoration: BoxDecoration(
+                        color: Colors.grey.shade300,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      clipBehavior: Clip.antiAlias,
+                      child: CustomPaint(
+                        size: const Size(double.infinity, 120),
+                        painter: _WaveformPainter(_waveform!),
+                      ),
+                    ),
+                  ],
+                ],
               ),
-              if (_waveform != null) ...[
-                const SizedBox(height: 12),
-                Container(
-                  height: 100,
-                  decoration: BoxDecoration(
-                    color: Colors.grey.shade300,
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  clipBehavior: Clip.antiAlias,
-                  child: CustomPaint(
-                    size: const Size(double.infinity, 120),
-                    painter: _WaveformPainter(_waveform!),
-                  ),
+            ),
+            const Divider(height: 1),
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    const Text(
+                      'Conversion',
+                      style: TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 8),
+                    ElevatedButton(
+                      onPressed: _busy
+                          ? null
+                          : () => _convertToWav('assets/test_tone.mp3'),
+                      child: const Text('Convert MP3 → WAV'),
+                    ),
+                    const SizedBox(height: 8),
+                    ElevatedButton(
+                      onPressed: _busy
+                          ? null
+                          : () => _convertToWav('assets/test_tone.m4a'),
+                      child: const Text('Convert M4A → WAV'),
+                    ),
+                    const SizedBox(height: 8),
+                    ElevatedButton(
+                      onPressed: _busy
+                          ? null
+                          : () => _convertToM4a('assets/test_tone.wav'),
+                      child: const Text('Convert WAV → M4A'),
+                    ),
+                    const SizedBox(height: 20),
+                    const Text(
+                      'Info & Analysis',
+                      style: TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 8),
+                    ElevatedButton(
+                      onPressed: _busy
+                          ? null
+                          : () => _getAudioInfo('assets/test_tone.mp3'),
+                      child: const Text('Get Audio Info (MP3)'),
+                    ),
+                    const SizedBox(height: 8),
+                    ElevatedButton(
+                      onPressed: _busy
+                          ? null
+                          : () => _getWaveform('assets/test_tone.mp3'),
+                      child: const Text('Get Waveform (MP3)'),
+                    ),
+                    const SizedBox(height: 20),
+                    const Text('Trim', style: TextStyle(fontWeight: FontWeight.bold)),
+                    const SizedBox(height: 8),
+                    ElevatedButton(
+                      onPressed: _busy
+                          ? null
+                          : () => _trimAudio('assets/test_tone.mp3'),
+                      child: const Text('Trim MP3 (0.2s - 0.8s) → WAV'),
+                    ),
+                    const SizedBox(height: 20),
+                    const Text(
+                      'Bytes API (in-memory)',
+                      style: TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 8),
+                    ElevatedButton(
+                      onPressed: _busy
+                          ? null
+                          : () => _convertToWavBytes('assets/test_tone.mp3'),
+                      child: const Text('Convert MP3 → WAV (bytes)'),
+                    ),
+                    const SizedBox(height: 8),
+                    ElevatedButton(
+                      onPressed: _busy
+                          ? null
+                          : () => _convertToRawPcmBytes('assets/test_tone.mp3'),
+                      child: const Text('Convert MP3 → raw PCM (bytes)'),
+                    ),
+                    const SizedBox(height: 8),
+                    ElevatedButton(
+                      onPressed: _busy
+                          ? null
+                          : () => _getAudioInfoBytes('assets/test_tone.mp3'),
+                      child: const Text('Get Audio Info (bytes)'),
+                    ),
+                    const SizedBox(height: 8),
+                    ElevatedButton(
+                      onPressed: _busy
+                          ? null
+                          : () => _trimAudioBytes('assets/test_tone.mp3'),
+                      child: const Text('Trim MP3 (0.2s - 0.8s, bytes)'),
+                    ),
+                    const SizedBox(height: 8),
+                    ElevatedButton(
+                      onPressed: _busy
+                          ? null
+                          : () => _getWaveformBytes('assets/test_tone.mp3'),
+                      child: const Text('Get Waveform (bytes)'),
+                    ),
+                  ],
                 ),
-              ],
-              const SizedBox(height: 24),
-              const Text(
-                'Conversion',
-                style: TextStyle(fontWeight: FontWeight.bold),
               ),
-              const SizedBox(height: 8),
-              ElevatedButton(
-                onPressed: _busy
-                    ? null
-                    : () => _convertToWav('assets/test_tone.mp3'),
-                child: const Text('Convert MP3 → WAV'),
-              ),
-              const SizedBox(height: 8),
-              ElevatedButton(
-                onPressed: _busy
-                    ? null
-                    : () => _convertToWav('assets/test_tone.m4a'),
-                child: const Text('Convert M4A → WAV'),
-              ),
-              const SizedBox(height: 8),
-              ElevatedButton(
-                onPressed: _busy
-                    ? null
-                    : () => _convertToM4a('assets/test_tone.wav'),
-                child: const Text('Convert WAV → M4A'),
-              ),
-              const SizedBox(height: 20),
-              const Text(
-                'Info & Analysis',
-                style: TextStyle(fontWeight: FontWeight.bold),
-              ),
-              const SizedBox(height: 8),
-              ElevatedButton(
-                onPressed: _busy
-                    ? null
-                    : () => _getAudioInfo('assets/test_tone.mp3'),
-                child: const Text('Get Audio Info (MP3)'),
-              ),
-              const SizedBox(height: 8),
-              ElevatedButton(
-                onPressed: _busy
-                    ? null
-                    : () => _getWaveform('assets/test_tone.mp3'),
-                child: const Text('Get Waveform (MP3)'),
-              ),
-              const SizedBox(height: 20),
-              const Text('Trim', style: TextStyle(fontWeight: FontWeight.bold)),
-              const SizedBox(height: 8),
-              ElevatedButton(
-                onPressed: _busy
-                    ? null
-                    : () => _trimAudio('assets/test_tone.mp3'),
-                child: const Text('Trim MP3 (0.2s - 0.8s) → WAV'),
-              ),
-              const SizedBox(height: 20),
-              const Text(
-                'Bytes API (in-memory)',
-                style: TextStyle(fontWeight: FontWeight.bold),
-              ),
-              const SizedBox(height: 8),
-              ElevatedButton(
-                onPressed: _busy
-                    ? null
-                    : () => _convertToWavBytes('assets/test_tone.mp3'),
-                child: const Text('Convert MP3 → WAV (bytes)'),
-              ),
-              const SizedBox(height: 8),
-              ElevatedButton(
-                onPressed: _busy
-                    ? null
-                    : () => _convertToRawPcmBytes('assets/test_tone.mp3'),
-                child: const Text('Convert MP3 → raw PCM (bytes)'),
-              ),
-              const SizedBox(height: 8),
-              ElevatedButton(
-                onPressed: _busy
-                    ? null
-                    : () => _getAudioInfoBytes('assets/test_tone.mp3'),
-                child: const Text('Get Audio Info (bytes)'),
-              ),
-              const SizedBox(height: 8),
-              ElevatedButton(
-                onPressed: _busy
-                    ? null
-                    : () => _trimAudioBytes('assets/test_tone.mp3'),
-                child: const Text('Trim MP3 (0.2s - 0.8s, bytes)'),
-              ),
-              const SizedBox(height: 8),
-              ElevatedButton(
-                onPressed: _busy
-                    ? null
-                    : () => _getWaveformBytes('assets/test_tone.mp3'),
-                child: const Text('Get Waveform (bytes)'),
-              ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -15,7 +15,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.6.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/ios/Classes/AudioDecoderPlugin.swift
+++ b/ios/Classes/AudioDecoderPlugin.swift
@@ -207,7 +207,7 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
             if let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) {
                 let length = CMBlockBufferGetDataLength(blockBuffer)
                 var data = Data(count: length)
-                data.withUnsafeMutableBytes { ptr in
+                _ = data.withUnsafeMutableBytes { ptr in
                     CMBlockBufferCopyDataBytes(blockBuffer, atOffset: 0, dataLength: length,
                                                destination: ptr.baseAddress!)
                 }
@@ -472,7 +472,7 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
                 if let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) {
                     let length = CMBlockBufferGetDataLength(blockBuffer)
                     var data = Data(count: length)
-                    data.withUnsafeMutableBytes { ptr in
+                    _ = data.withUnsafeMutableBytes { ptr in
                         CMBlockBufferCopyDataBytes(blockBuffer, atOffset: 0, dataLength: length,
                                                    destination: ptr.baseAddress!)
                     }
@@ -560,7 +560,7 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
             if let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) {
                 let length = CMBlockBufferGetDataLength(blockBuffer)
                 var data = Data(count: length)
-                data.withUnsafeMutableBytes { ptr in
+                _ = data.withUnsafeMutableBytes { ptr in
                     CMBlockBufferCopyDataBytes(blockBuffer, atOffset: 0, dataLength: length,
                                                destination: ptr.baseAddress!)
                 }

--- a/ios/Classes/AudioDecoderPlugin.swift
+++ b/ios/Classes/AudioDecoderPlugin.swift
@@ -88,7 +88,8 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
             let sampleRate = args["sampleRate"] as? Int
             let channels = args["channels"] as? Int
             let bitDepth = args["bitDepth"] as? Int
-            convertToWavBytes(inputData: inputData, formatHint: formatHint, sampleRate: sampleRate, channels: channels, bitDepth: bitDepth, result: result)
+            let includeHeader = args["includeHeader"] as? Bool ?? true
+            convertToWavBytes(inputData: inputData, formatHint: formatHint, sampleRate: sampleRate, channels: channels, bitDepth: bitDepth, includeHeader: includeHeader, result: result)
         case "convertToM4aBytes":
             guard let args = call.arguments as? [String: Any],
                   let inputData = args["inputData"] as? FlutterStandardTypedData,
@@ -622,7 +623,7 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
 
     // MARK: - Bytes-based methods
 
-    private func convertToWavBytes(inputData: FlutterStandardTypedData, formatHint: String, sampleRate: Int?, channels: Int?, bitDepth: Int?, result: @escaping FlutterResult) {
+    private func convertToWavBytes(inputData: FlutterStandardTypedData, formatHint: String, sampleRate: Int?, channels: Int?, bitDepth: Int?, includeHeader: Bool = true, result: @escaping FlutterResult) {
         DispatchQueue.global(qos: .userInitiated).async {
             do {
                 let tempInputURL = try self.writeTempInput(data: inputData, formatHint: formatHint)
@@ -632,7 +633,10 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
                     try? FileManager.default.removeItem(at: tempOutputURL)
                 }
                 try self.performConversion(inputPath: tempInputURL.path, outputPath: tempOutputURL.path, targetSampleRate: sampleRate, targetChannels: channels, targetBitDepth: bitDepth)
-                let outputData = try Data(contentsOf: tempOutputURL)
+                var outputData = try Data(contentsOf: tempOutputURL)
+                if !includeHeader && outputData.count > 44 {
+                    outputData = outputData.subdata(in: 44..<outputData.count)
+                }
                 DispatchQueue.main.async {
                     result(FlutterStandardTypedData(bytes: outputData))
                 }

--- a/ios/Classes/AudioDecoderPlugin.swift
+++ b/ios/Classes/AudioDecoderPlugin.swift
@@ -3,6 +3,9 @@ import UIKit
 import AVFoundation
 
 public class AudioDecoderPlugin: NSObject, FlutterPlugin {
+    /// Standard RIFF/WAV header size in bytes (no extra chunks).
+    private static let wavHeaderSize = 44
+
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(
             name: "audio_decoder",
@@ -634,8 +637,10 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
                 }
                 try self.performConversion(inputPath: tempInputURL.path, outputPath: tempOutputURL.path, targetSampleRate: sampleRate, targetChannels: channels, targetBitDepth: bitDepth)
                 var outputData = try Data(contentsOf: tempOutputURL)
-                if !includeHeader && outputData.count > 44 {
-                    outputData = outputData.subdata(in: 44..<outputData.count)
+                // Strip the WAV header to return raw PCM.
+                let h = AudioDecoderPlugin.wavHeaderSize
+                if !includeHeader && outputData.count >= h {
+                    outputData = outputData.subdata(in: h..<outputData.count)
                 }
                 DispatchQueue.main.async {
                     result(FlutterStandardTypedData(bytes: outputData))

--- a/lib/audio_decoder.dart
+++ b/lib/audio_decoder.dart
@@ -124,8 +124,10 @@ class AudioDecoder {
   /// [sampleRate] optionally sets the output sample rate (e.g., 44100). Defaults to source sample rate.
   /// [channels] optionally sets the number of output channels (e.g., 1 for mono, 2 for stereo). Defaults to source channels.
   /// [bitDepth] optionally sets the output bit depth (e.g., 16, 24). Defaults to 16.
+  /// [includeHeader] when true (default), returns a complete WAV file with the
+  /// 44-byte RIFF/WAV header. When false, returns only raw interleaved PCM data.
   ///
-  /// Returns the WAV file bytes.
+  /// Returns the WAV file bytes (or raw PCM bytes if [includeHeader] is false).
   /// Throws [AudioConversionException] on failure.
   static Future<Uint8List> convertToWavBytes(
     Uint8List inputData, {
@@ -133,8 +135,11 @@ class AudioDecoder {
     int? sampleRate,
     int? channels,
     int? bitDepth,
+    bool includeHeader = true,
   }) {
-    return AudioDecoderPlatform.instance.convertToWavBytes(inputData, formatHint, sampleRate: sampleRate, channels: channels, bitDepth: bitDepth);
+    return AudioDecoderPlatform.instance.convertToWavBytes(inputData, formatHint,
+        sampleRate: sampleRate, channels: channels, bitDepth: bitDepth,
+        includeHeader: includeHeader);
   }
 
   /// Converts audio bytes to M4A (AAC) format.

--- a/lib/audio_decoder_method_channel.dart
+++ b/lib/audio_decoder_method_channel.dart
@@ -125,7 +125,7 @@ class MethodChannelAudioDecoder extends AudioDecoderPlatform {
   }
 
   @override
-  Future<Uint8List> convertToWavBytes(Uint8List inputData, String formatHint, {int? sampleRate, int? channels, int? bitDepth}) async {
+  Future<Uint8List> convertToWavBytes(Uint8List inputData, String formatHint, {int? sampleRate, int? channels, int? bitDepth, bool? includeHeader}) async {
     try {
       final args = <String, dynamic>{
         'inputData': inputData,
@@ -134,6 +134,7 @@ class MethodChannelAudioDecoder extends AudioDecoderPlatform {
       if (sampleRate != null) args['sampleRate'] = sampleRate;
       if (channels != null) args['channels'] = channels;
       if (bitDepth != null) args['bitDepth'] = bitDepth;
+      if (includeHeader != null && includeHeader == false) args['includeHeader'] = false;
       final result = await methodChannel.invokeMethod<Uint8List>(
         'convertToWavBytes',
         args,

--- a/lib/audio_decoder_platform_interface.dart
+++ b/lib/audio_decoder_platform_interface.dart
@@ -47,7 +47,7 @@ abstract class AudioDecoderPlatform extends PlatformInterface {
     throw UnimplementedError('getWaveform() has not been implemented.');
   }
 
-  Future<Uint8List> convertToWavBytes(Uint8List inputData, String formatHint, {int? sampleRate, int? channels, int? bitDepth}) {
+  Future<Uint8List> convertToWavBytes(Uint8List inputData, String formatHint, {int? sampleRate, int? channels, int? bitDepth, bool? includeHeader}) {
     throw UnimplementedError('convertToWavBytes() has not been implemented.');
   }
 

--- a/lib/audio_decoder_web.dart
+++ b/lib/audio_decoder_web.dart
@@ -9,6 +9,9 @@ import 'audio_conversion_exception.dart';
 import 'audio_decoder_platform_interface.dart';
 import 'audio_info.dart';
 
+/// Standard RIFF/WAV header size in bytes (no extra chunks).
+const int _wavHeaderSize = 44;
+
 /// Web platform implementation of audio_decoder using the Web Audio API.
 ///
 /// File-based methods are not supported and throw [UnsupportedError].
@@ -84,7 +87,7 @@ class AudioDecoderWeb extends AudioDecoderPlatform {
     final bytesPerSample = bitsPerSample ~/ 8;
     final blockAlign = numChannels * bytesPerSample;
     final dataSize = numFrames * blockAlign;
-    final headerSize = includeHeader ? 44 : 0;
+    final headerSize = includeHeader ? _wavHeaderSize : 0;
     final fileSize = headerSize + dataSize;
 
     final channels = <Float32List>[];

--- a/lib/audio_decoder_web.dart
+++ b/lib/audio_decoder_web.dart
@@ -72,7 +72,8 @@ class AudioDecoderWeb extends AudioDecoderPlatform {
   }
 
   Uint8List _encodeWav(web.AudioBuffer buffer,
-      {int? startSample, int? endSample, int? targetChannels, int? targetBitDepth}) {
+      {int? startSample, int? endSample, int? targetChannels, int? targetBitDepth,
+       bool includeHeader = true}) {
     final sampleRate = buffer.sampleRate.toInt();
     final srcChannels = buffer.numberOfChannels;
     final numChannels = targetChannels ?? srcChannels;
@@ -83,7 +84,8 @@ class AudioDecoderWeb extends AudioDecoderPlatform {
     final bytesPerSample = bitsPerSample ~/ 8;
     final blockAlign = numChannels * bytesPerSample;
     final dataSize = numFrames * blockAlign;
-    final fileSize = 44 + dataSize;
+    final headerSize = includeHeader ? 44 : 0;
+    final fileSize = headerSize + dataSize;
 
     final channels = <Float32List>[];
     for (var ch = 0; ch < srcChannels; ch++) {
@@ -119,39 +121,41 @@ class AudioDecoderWeb extends AudioDecoderPlatform {
     final data = ByteData(fileSize);
     var pos = 0;
 
-    void writeString(String s) {
-      for (var i = 0; i < s.length; i++) {
-        data.setUint8(pos++, s.codeUnitAt(i));
+    if (includeHeader) {
+      void writeString(String s) {
+        for (var i = 0; i < s.length; i++) {
+          data.setUint8(pos++, s.codeUnitAt(i));
+        }
       }
+
+      // RIFF header
+      writeString('RIFF');
+      data.setUint32(pos, 36 + dataSize, Endian.little);
+      pos += 4;
+      writeString('WAVE');
+
+      // fmt chunk
+      writeString('fmt ');
+      data.setUint32(pos, 16, Endian.little);
+      pos += 4;
+      data.setUint16(pos, 1, Endian.little);
+      pos += 2; // PCM
+      data.setUint16(pos, numChannels, Endian.little);
+      pos += 2;
+      data.setUint32(pos, sampleRate, Endian.little);
+      pos += 4;
+      data.setUint32(pos, sampleRate * blockAlign, Endian.little);
+      pos += 4;
+      data.setUint16(pos, blockAlign, Endian.little);
+      pos += 2;
+      data.setUint16(pos, bitsPerSample, Endian.little);
+      pos += 2;
+
+      // data chunk
+      writeString('data');
+      data.setUint32(pos, dataSize, Endian.little);
+      pos += 4;
     }
-
-    // RIFF header
-    writeString('RIFF');
-    data.setUint32(pos, 36 + dataSize, Endian.little);
-    pos += 4;
-    writeString('WAVE');
-
-    // fmt chunk
-    writeString('fmt ');
-    data.setUint32(pos, 16, Endian.little);
-    pos += 4;
-    data.setUint16(pos, 1, Endian.little);
-    pos += 2; // PCM
-    data.setUint16(pos, numChannels, Endian.little);
-    pos += 2;
-    data.setUint32(pos, sampleRate, Endian.little);
-    pos += 4;
-    data.setUint32(pos, sampleRate * blockAlign, Endian.little);
-    pos += 4;
-    data.setUint16(pos, blockAlign, Endian.little);
-    pos += 2;
-    data.setUint16(pos, bitsPerSample, Endian.little);
-    pos += 2;
-
-    // data chunk
-    writeString('data');
-    data.setUint32(pos, dataSize, Endian.little);
-    pos += 4;
 
     // Interleaved PCM samples
     final maxVal = (1 << (bitsPerSample - 1)) - 1;
@@ -182,13 +186,14 @@ class AudioDecoderWeb extends AudioDecoderPlatform {
 
   @override
   Future<Uint8List> convertToWavBytes(
-      Uint8List inputData, String formatHint, {int? sampleRate, int? channels, int? bitDepth}) async {
+      Uint8List inputData, String formatHint, {int? sampleRate, int? channels, int? bitDepth, bool? includeHeader}) async {
     try {
       var buffer = await _decodeAudioData(inputData);
       if (sampleRate != null && sampleRate != buffer.sampleRate.toInt()) {
         buffer = await _resample(buffer, sampleRate);
       }
-      return _encodeWav(buffer, targetChannels: channels, targetBitDepth: bitDepth);
+      return _encodeWav(buffer, targetChannels: channels, targetBitDepth: bitDepth,
+          includeHeader: includeHeader ?? true);
     } catch (e) {
       if (e is AudioConversionException) rethrow;
       throw AudioConversionException('WAV conversion failed: $e');

--- a/linux/audio_decoder_plugin.cc
+++ b/linux/audio_decoder_plugin.cc
@@ -18,6 +18,9 @@
 #include <vector>
 #include <thread>
 
+/// Standard RIFF/WAV header size in bytes (no extra chunks).
+static constexpr size_t kWavHeaderSize = 44;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -747,8 +750,9 @@ static void handle_method_call(AudioDecoderPlugin* self,
                     ConvertToWav(tempInput, tempOutput, targetSampleRate, targetChannels, targetBitDepth);
                     auto outputBytes = ReadAndDeleteFile(tempOutput);
                     std::remove(tempInput.c_str());
-                    if (!includeHeader && outputBytes.size() > 44) {
-                        outputBytes.erase(outputBytes.begin(), outputBytes.begin() + 44);
+                    // Strip the WAV header to return raw PCM.
+                    if (!includeHeader && outputBytes.size() >= kWavHeaderSize) {
+                        outputBytes.erase(outputBytes.begin(), outputBytes.begin() + kWavHeaderSize);
                     }
                     g_autoptr(FlValue) val = fl_value_new_uint8_list(
                         outputBytes.data(), outputBytes.size());

--- a/macos/Classes/AudioDecoderPlugin.swift
+++ b/macos/Classes/AudioDecoderPlugin.swift
@@ -207,7 +207,7 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
             if let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) {
                 let length = CMBlockBufferGetDataLength(blockBuffer)
                 var data = Data(count: length)
-                data.withUnsafeMutableBytes { ptr in
+                _ = data.withUnsafeMutableBytes { ptr in
                     CMBlockBufferCopyDataBytes(blockBuffer, atOffset: 0, dataLength: length,
                                                destination: ptr.baseAddress!)
                 }
@@ -470,7 +470,7 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
                 if let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) {
                     let length = CMBlockBufferGetDataLength(blockBuffer)
                     var data = Data(count: length)
-                    data.withUnsafeMutableBytes { ptr in
+                    _ = data.withUnsafeMutableBytes { ptr in
                         CMBlockBufferCopyDataBytes(blockBuffer, atOffset: 0, dataLength: length,
                                                    destination: ptr.baseAddress!)
                     }
@@ -557,7 +557,7 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
             if let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) {
                 let length = CMBlockBufferGetDataLength(blockBuffer)
                 var data = Data(count: length)
-                data.withUnsafeMutableBytes { ptr in
+                _ = data.withUnsafeMutableBytes { ptr in
                     CMBlockBufferCopyDataBytes(blockBuffer, atOffset: 0, dataLength: length,
                                                destination: ptr.baseAddress!)
                 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_decoder
 description: "A lightweight Flutter plugin for converting, trimming, and analyzing audio files using native platform APIs. No FFmpeg required."
-version: 0.5.0
+version: 0.6.0
 homepage: https://www.silversoft.nl
 repository: https://github.com/sjoenk/audio_decoder
 

--- a/test/audio_decoder_method_channel_test.dart
+++ b/test/audio_decoder_method_channel_test.dart
@@ -330,5 +330,34 @@ void main() {
           sampleRate: 22050, channels: 1, bitDepth: 8);
       expect(result, wavBytes);
     });
+
+    test('convertToWavBytes sends includeHeader when false', () async {
+      final pcmBytes = Uint8List.fromList([0x01, 0x02]);
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, (
+        MethodCall methodCall,
+      ) async {
+        expect(methodCall.method, 'convertToWavBytes');
+        expect(methodCall.arguments['includeHeader'], false);
+        return pcmBytes;
+      });
+
+      final result = await platform.convertToWavBytes(testInput, 'mp3',
+          includeHeader: false);
+      expect(result, pcmBytes);
+    });
+
+    test('convertToWavBytes omits includeHeader when null (default)', () async {
+      final wavBytes = Uint8List.fromList([0x52, 0x49, 0x46, 0x46]);
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, (
+        MethodCall methodCall,
+      ) async {
+        expect(methodCall.method, 'convertToWavBytes');
+        expect(methodCall.arguments.containsKey('includeHeader'), false);
+        return wavBytes;
+      });
+
+      final result = await platform.convertToWavBytes(testInput, 'mp3');
+      expect(result, wavBytes);
+    });
   });
 }

--- a/windows/audio_decoder_plugin.cpp
+++ b/windows/audio_decoder_plugin.cpp
@@ -25,6 +25,9 @@
 #pragma comment(lib, "mfuuid.lib")
 #pragma comment(lib, "mf.lib")
 
+/// Standard RIFF/WAV header size in bytes (no extra chunks).
+static constexpr size_t kWavHeaderSize = 44;
+
 static std::wstring Utf8ToWide(const std::string& utf8) {
     if (utf8.empty()) return {};
     int size = MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, nullptr, 0);
@@ -262,8 +265,9 @@ void AudioDecoderPlugin::HandleMethodCall(
                     ConvertToWav(tempInput, tempOutput, targetSampleRate, targetChannels, targetBitDepth);
                     auto outputBytes = ReadAndDeleteFile(tempOutput);
                     DeleteFileW(Utf8ToWide(tempInput).c_str());
-                    if (!includeHeader && outputBytes.size() > 44) {
-                        outputBytes.erase(outputBytes.begin(), outputBytes.begin() + 44);
+                    // Strip the WAV header to return raw PCM.
+                    if (!includeHeader && outputBytes.size() >= kWavHeaderSize) {
+                        outputBytes.erase(outputBytes.begin(), outputBytes.begin() + kWavHeaderSize);
                     }
                     shared_result->Success(flutter::EncodableValue(outputBytes));
                 } catch (...) {


### PR DESCRIPTION
## Summary

- Add `includeHeader` parameter to `convertToWavBytes()` (default `true`)
- When `false`, returns only raw interleaved PCM data without the 44-byte RIFF/WAV header
- Implemented on all 6 platforms (iOS, macOS, Android, Windows, Linux, Web)
- Backward-compatible: existing callers are unaffected

Closes #6

## Test plan

- [x] All 44 existing + new unit tests pass (`flutter test`)
- [x] `flutter analyze` reports no issues
- [ ] Manual verification on a physical device with `includeHeader: false`