### PR TITLE
Add Dart 3 class modifiers to all classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 * When `false`, returns only raw interleaved PCM data without the 44-byte RIFF/WAV header.
 * Useful for real-time audio pipelines, direct hardware interfaces, and custom audio processing.
 * Supported on all platforms: Android, iOS, macOS, Windows, Linux, and Web.
+* Add Dart 3 class modifiers to all library classes.
+* `AudioDecoderPlatform` is now `abstract base class` — enforces extension over implementation.
+* `MethodChannelAudioDecoder`, `AudioDecoderWeb`, `AudioDecoder`, `AudioConversionException`, and `AudioInfo` are now `final class` — prevents unintended subclassing.
 
 ## 0.5.0
 

--- a/lib/audio_conversion_exception.dart
+++ b/lib/audio_conversion_exception.dart
@@ -2,7 +2,7 @@
 ///
 /// Contains a human-readable [message] and optional [details] from the
 /// native platform.
-class AudioConversionException implements Exception {
+final class AudioConversionException implements Exception {
   /// A human-readable description of the error.
   final String message;
 

--- a/lib/audio_decoder.dart
+++ b/lib/audio_decoder.dart
@@ -10,7 +10,7 @@ export 'audio_info.dart';
 ///
 /// Provides static methods for converting, trimming, analyzing, and extracting
 /// waveform data from audio files and in-memory audio bytes.
-class AudioDecoder {
+final class AudioDecoder {
   /// Converts an audio file (MP3, M4A, AAC, etc.) to WAV format.
   ///
   /// [inputPath] is the absolute path to the source audio file.

--- a/lib/audio_decoder_method_channel.dart
+++ b/lib/audio_decoder_method_channel.dart
@@ -7,7 +7,7 @@ import 'audio_info.dart';
 
 /// Platform implementation of audio_decoder that uses a method channel to
 /// communicate with native platform code.
-class MethodChannelAudioDecoder extends AudioDecoderPlatform {
+final class MethodChannelAudioDecoder extends AudioDecoderPlatform {
   @visibleForTesting
   final methodChannel = const MethodChannel('audio_decoder');
 

--- a/lib/audio_decoder_platform_interface.dart
+++ b/lib/audio_decoder_platform_interface.dart
@@ -6,11 +6,12 @@ import 'audio_decoder_method_channel.dart';
 import 'audio_info.dart';
 
 /// The interface that platform-specific implementations of audio_decoder must
-/// implement.
+/// extend.
 ///
-/// Platform implementations should extend this class rather than implement it,
-/// as new methods may be added in the future.
-abstract class AudioDecoderPlatform extends PlatformInterface {
+/// The `base` modifier ensures platform implementations extend this class
+/// rather than implement it, so new methods can be added without breaking
+/// existing implementations.
+abstract base class AudioDecoderPlatform extends PlatformInterface {
   /// Constructs an [AudioDecoderPlatform].
   AudioDecoderPlatform() : super(token: _token);
 

--- a/lib/audio_decoder_web.dart
+++ b/lib/audio_decoder_web.dart
@@ -16,7 +16,7 @@ const int _wavHeaderSize = 44;
 ///
 /// File-based methods are not supported and throw [UnsupportedError].
 /// Use the bytes-based API instead.
-class AudioDecoderWeb extends AudioDecoderPlatform {
+final class AudioDecoderWeb extends AudioDecoderPlatform {
   /// Creates an [AudioDecoderWeb] instance.
   AudioDecoderWeb();
 

--- a/lib/audio_info.dart
+++ b/lib/audio_info.dart
@@ -1,7 +1,7 @@
 /// Metadata about an audio file or audio data.
 ///
 /// Returned by [AudioDecoder.getAudioInfo] and [AudioDecoder.getAudioInfoBytes].
-class AudioInfo {
+final class AudioInfo {
   /// Total duration of the audio.
   final Duration duration;
 

--- a/test/audio_decoder_test.dart
+++ b/test/audio_decoder_test.dart
@@ -6,7 +6,7 @@ import 'package:audio_decoder/audio_decoder_platform_interface.dart';
 import 'package:audio_decoder/audio_decoder_method_channel.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
-class MockAudioDecoderPlatform with MockPlatformInterfaceMixin implements AudioDecoderPlatform {
+final class MockAudioDecoderPlatform extends AudioDecoderPlatform with MockPlatformInterfaceMixin {
   @override
   Future<String> convertToWav(String inputPath, String outputPath, {int? sampleRate, int? channels, int? bitDepth}) => Future.value(outputPath);
 


### PR DESCRIPTION
## Summary

- `AudioDecoderPlatform` → `abstract base class` — enforces extension over implementation, protecting the `PlatformInterface` token pattern
- `MethodChannelAudioDecoder`, `AudioDecoderWeb`, `AudioDecoder`, `AudioConversionException`, `AudioInfo` → `final class` — prevents unintended subclassing
- Updated `MockAudioDecoderPlatform` in tests to use `extends` instead of `implements`
- Updated doc comment on `AudioDecoderPlatform` and changelog

## Test plan

- [x] All 44 existing unit tests pass
- [x] Verified modifiers against [Dart 3 class modifiers spec](https://dart.dev/language/class-modifiers)
- [x] Subclass rules satisfied: all subclasses of `base` class are marked `final`

Closes #7