### PR TITLE
Add Dart-level input validation for WAV conversion parameters

### DIFF
--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -5,23 +5,16 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:audio_decoder_example/main.dart';
 
 void main() {
-  testWidgets('Verify Platform version', (WidgetTester tester) async {
+  testWidgets('App renders with initial status text', (WidgetTester tester) async {
     // Build our app and trigger a frame.
     await tester.pumpWidget(const MyApp());
 
-    // Verify that platform version is retrieved.
-    expect(
-      find.byWidgetPredicate(
-        (Widget widget) =>
-            widget is Text && widget.data!.startsWith('Running on:'),
-      ),
-      findsOneWidget,
-    );
+    // Verify that the app renders with the initial status text.
+    expect(find.text('Ready - tap a button to test audio operations.'), findsOneWidget);
   });
 }

--- a/lib/audio_decoder.dart
+++ b/lib/audio_decoder.dart
@@ -28,6 +28,7 @@ final class AudioDecoder {
     int? channels,
     int? bitDepth,
   }) {
+    _validateWavParameters(sampleRate: sampleRate, channels: channels, bitDepth: bitDepth);
     return AudioDecoderPlatform.instance.convertToWav(inputPath, outputPath, sampleRate: sampleRate, channels: channels, bitDepth: bitDepth);
   }
 
@@ -79,6 +80,20 @@ final class AudioDecoder {
     int numberOfSamples = 100,
   }) {
     return AudioDecoderPlatform.instance.getWaveform(path, numberOfSamples);
+  }
+
+  /// Validates [sampleRate], [channels], and [bitDepth] parameters
+  /// shared by all WAV conversion methods.
+  static void _validateWavParameters({int? sampleRate, int? channels, int? bitDepth}) {
+    if (sampleRate != null && sampleRate <= 0) {
+      throw ArgumentError.value(sampleRate, 'sampleRate', 'Must be positive');
+    }
+    if (channels != null && channels <= 0) {
+      throw ArgumentError.value(channels, 'channels', 'Must be positive');
+    }
+    if (bitDepth != null && ![8, 16, 24, 32].contains(bitDepth)) {
+      throw ArgumentError.value(bitDepth, 'bitDepth', 'Must be 8, 16, 24, or 32');
+    }
   }
 
   /// Known audio extensions that can be converted to WAV.
@@ -137,6 +152,7 @@ final class AudioDecoder {
     int? bitDepth,
     bool includeHeader = true,
   }) {
+    _validateWavParameters(sampleRate: sampleRate, channels: channels, bitDepth: bitDepth);
     return AudioDecoderPlatform.instance.convertToWavBytes(inputData, formatHint,
         sampleRate: sampleRate, channels: channels, bitDepth: bitDepth,
         includeHeader: includeHeader);

--- a/lib/audio_decoder.dart
+++ b/lib/audio_decoder.dart
@@ -91,7 +91,7 @@ final class AudioDecoder {
     if (channels != null && channels <= 0) {
       throw ArgumentError.value(channels, 'channels', 'Must be positive');
     }
-    if (bitDepth != null && ![8, 16, 24, 32].contains(bitDepth)) {
+    if (bitDepth != null && !const [8, 16, 24, 32].contains(bitDepth)) {
       throw ArgumentError.value(bitDepth, 'bitDepth', 'Must be 8, 16, 24, or 32');
     }
   }

--- a/lib/audio_decoder.dart
+++ b/lib/audio_decoder.dart
@@ -20,6 +20,7 @@ final class AudioDecoder {
   /// [bitDepth] optionally sets the output bit depth (e.g., 16, 24). Defaults to 16.
   ///
   /// Returns the output path on success.
+  /// Throws [ArgumentError] if [sampleRate], [channels], or [bitDepth] is invalid.
   /// Throws [AudioConversionException] on failure.
   static Future<String> convertToWav(
     String inputPath,
@@ -143,6 +144,7 @@ final class AudioDecoder {
   /// 44-byte RIFF/WAV header. When false, returns only raw interleaved PCM data.
   ///
   /// Returns the WAV file bytes (or raw PCM bytes if [includeHeader] is false).
+  /// Throws [ArgumentError] if [sampleRate], [channels], or [bitDepth] is invalid.
   /// Throws [AudioConversionException] on failure.
   static Future<Uint8List> convertToWavBytes(
     Uint8List inputData, {

--- a/test/audio_decoder_test.dart
+++ b/test/audio_decoder_test.dart
@@ -214,6 +214,88 @@ void main() {
     });
   });
 
+  group('parameter validation', () {
+    late MockAudioDecoderPlatform fakePlatform;
+
+    setUp(() {
+      fakePlatform = MockAudioDecoderPlatform();
+      AudioDecoderPlatform.instance = fakePlatform;
+    });
+
+    test('convertToWav rejects zero sampleRate', () {
+      expect(
+        () => AudioDecoder.convertToWav('/in.mp3', '/out.wav', sampleRate: 0),
+        throwsArgumentError,
+      );
+    });
+
+    test('convertToWav rejects negative sampleRate', () {
+      expect(
+        () => AudioDecoder.convertToWav('/in.mp3', '/out.wav', sampleRate: -1),
+        throwsArgumentError,
+      );
+    });
+
+    test('convertToWav rejects zero channels', () {
+      expect(
+        () => AudioDecoder.convertToWav('/in.mp3', '/out.wav', channels: 0),
+        throwsArgumentError,
+      );
+    });
+
+    test('convertToWav rejects negative channels', () {
+      expect(
+        () => AudioDecoder.convertToWav('/in.mp3', '/out.wav', channels: -5),
+        throwsArgumentError,
+      );
+    });
+
+    test('convertToWav rejects invalid bitDepth', () {
+      expect(
+        () => AudioDecoder.convertToWav('/in.mp3', '/out.wav', bitDepth: 12),
+        throwsArgumentError,
+      );
+    });
+
+    test('convertToWavBytes rejects zero sampleRate', () {
+      expect(
+        () => AudioDecoder.convertToWavBytes(Uint8List(1), formatHint: 'mp3', sampleRate: 0),
+        throwsArgumentError,
+      );
+    });
+
+    test('convertToWavBytes rejects negative channels', () {
+      expect(
+        () => AudioDecoder.convertToWavBytes(Uint8List(1), formatHint: 'mp3', channels: -1),
+        throwsArgumentError,
+      );
+    });
+
+    test('convertToWavBytes rejects invalid bitDepth', () {
+      expect(
+        () => AudioDecoder.convertToWavBytes(Uint8List(1), formatHint: 'mp3', bitDepth: 7),
+        throwsArgumentError,
+      );
+    });
+
+    test('convertToWav accepts valid parameters', () async {
+      final result = await AudioDecoder.convertToWav('/in.mp3', '/out.wav',
+          sampleRate: 44100, channels: 2, bitDepth: 16);
+      expect(result, '/out.wav');
+    });
+
+    test('convertToWavBytes accepts all valid bitDepths', () async {
+      for (final depth in [8, 16, 24, 32]) {
+        final result = await AudioDecoder.convertToWavBytes(
+          Uint8List.fromList([1, 2, 3]),
+          formatHint: 'mp3',
+          bitDepth: depth,
+        );
+        expect(result, isNotEmpty, reason: 'bitDepth $depth should be valid');
+      }
+    });
+  });
+
   group('convertToWav with optional parameters', () {
     late MockAudioDecoderPlatform fakePlatform;
 


### PR DESCRIPTION
## Summary
- Add shared `_validateWavParameters()` helper that validates `sampleRate`, `channels`, and `bitDepth` before passing them to native platforms
- Apply validation in both `convertToWav()` and `convertToWavBytes()`
- Add 10 unit tests covering invalid and valid parameter combinations

## Validation rules
| Parameter | Rule |
|---|---|
| `sampleRate` | Must be positive (> 0) |
| `channels` | Must be positive (> 0) |
| `bitDepth` | Must be 8, 16, 24, or 32 |

Invalid values throw `ArgumentError` at the Dart level, preventing inconsistent native crashes.

Closes #12