### PR TITLE
Stream decoded PCM to disk during Android WAV conversion

### DIFF
--- a/android/src/main/kotlin/nl/silversoft/audio_decoder/AudioDecoderPlugin.kt
+++ b/android/src/main/kotlin/nl/silversoft/audio_decoder/AudioDecoderPlugin.kt
@@ -398,6 +398,8 @@ class AudioDecoderPlugin : FlutterPlugin, MethodCallHandler {
                             }
                             if (bufferInfo.size > 0) {
                                 val outputBuffer = codec.getOutputBuffer(outputBufferIndex)!!
+                                outputBuffer.position(bufferInfo.offset)
+                                outputBuffer.limit(bufferInfo.offset + bufferInfo.size)
                                 val rawChunk = ByteArray(bufferInfo.size)
                                 outputBuffer.get(rawChunk)
 
@@ -479,6 +481,8 @@ class AudioDecoderPlugin : FlutterPlugin, MethodCallHandler {
                     }
                     if (bufferInfo.size > 0) {
                         val outputBuffer = codec.getOutputBuffer(outputBufferIndex)!!
+                        outputBuffer.position(bufferInfo.offset)
+                        outputBuffer.limit(bufferInfo.offset + bufferInfo.size)
                         val chunk = ByteArray(bufferInfo.size)
                         outputBuffer.get(chunk)
                         pcmOutput.write(chunk)

--- a/android/src/main/kotlin/nl/silversoft/audio_decoder/AudioDecoderPlugin.kt
+++ b/android/src/main/kotlin/nl/silversoft/audio_decoder/AudioDecoderPlugin.kt
@@ -358,6 +358,7 @@ class AudioDecoderPlugin : FlutterPlugin, MethodCallHandler {
         var outputDone = false
         val timeoutUs = 10_000L
         val outputFile = File(outputPath)
+        outputFile.delete()
 
         try {
             RandomAccessFile(outputFile, "rw").use { raf ->

--- a/android/src/test/kotlin/nl/silversoft/audio_decoder/AudioDecoderPluginTest.kt
+++ b/android/src/test/kotlin/nl/silversoft/audio_decoder/AudioDecoderPluginTest.kt
@@ -6,8 +6,6 @@ import org.mockito.Mockito
 import kotlin.test.Test
 
 /*
- * This demonstrates a simple unit test of the Kotlin portion of this plugin's implementation.
- *
  * Once you have built the plugin's example app, you can run these tests from the command
  * line by running `./gradlew testDebugUnitTest` in the `example/android/` directory, or
  * you can run them directly from IDEs that support JUnit such as Android Studio.
@@ -15,13 +13,163 @@ import kotlin.test.Test
 
 internal class AudioDecoderPluginTest {
     @Test
-    fun onMethodCall_getPlatformVersion_returnsExpectedValue() {
+    fun onMethodCall_unknownMethod_returnsNotImplemented() {
         val plugin = AudioDecoderPlugin()
 
-        val call = MethodCall("getPlatformVersion", null)
+        val call = MethodCall("nonExistentMethod", null)
         val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
         plugin.onMethodCall(call, mockResult)
 
-        Mockito.verify(mockResult).success("Android " + android.os.Build.VERSION.RELEASE)
+        Mockito.verify(mockResult).notImplemented()
+    }
+
+    @Test
+    fun onMethodCall_convertToWav_missingArguments_returnsError() {
+        val plugin = AudioDecoderPlugin()
+
+        val call = MethodCall("convertToWav", mapOf("inputPath" to "/test.mp3"))
+        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
+        plugin.onMethodCall(call, mockResult)
+
+        Mockito.verify(mockResult).error(
+            Mockito.eq("INVALID_ARGUMENTS"),
+            Mockito.eq("inputPath and outputPath are required"),
+            Mockito.isNull()
+        )
+    }
+
+    @Test
+    fun onMethodCall_convertToM4a_missingArguments_returnsError() {
+        val plugin = AudioDecoderPlugin()
+
+        val call = MethodCall("convertToM4a", mapOf("inputPath" to "/test.wav"))
+        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
+        plugin.onMethodCall(call, mockResult)
+
+        Mockito.verify(mockResult).error(
+            Mockito.eq("INVALID_ARGUMENTS"),
+            Mockito.eq("inputPath and outputPath are required"),
+            Mockito.isNull()
+        )
+    }
+
+    @Test
+    fun onMethodCall_getAudioInfo_missingArguments_returnsError() {
+        val plugin = AudioDecoderPlugin()
+
+        val call = MethodCall("getAudioInfo", mapOf<String, Any>())
+        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
+        plugin.onMethodCall(call, mockResult)
+
+        Mockito.verify(mockResult).error(
+            Mockito.eq("INVALID_ARGUMENTS"),
+            Mockito.eq("path is required"),
+            Mockito.isNull()
+        )
+    }
+
+    @Test
+    fun onMethodCall_trimAudio_missingArguments_returnsError() {
+        val plugin = AudioDecoderPlugin()
+
+        val call = MethodCall("trimAudio", mapOf("inputPath" to "/test.mp3", "outputPath" to "/out.wav"))
+        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
+        plugin.onMethodCall(call, mockResult)
+
+        Mockito.verify(mockResult).error(
+            Mockito.eq("INVALID_ARGUMENTS"),
+            Mockito.eq("inputPath, outputPath, startMs and endMs are required"),
+            Mockito.isNull()
+        )
+    }
+
+    @Test
+    fun onMethodCall_getWaveform_missingArguments_returnsError() {
+        val plugin = AudioDecoderPlugin()
+
+        val call = MethodCall("getWaveform", mapOf<String, Any>())
+        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
+        plugin.onMethodCall(call, mockResult)
+
+        Mockito.verify(mockResult).error(
+            Mockito.eq("INVALID_ARGUMENTS"),
+            Mockito.eq("path and numberOfSamples are required"),
+            Mockito.isNull()
+        )
+    }
+
+    @Test
+    fun onMethodCall_convertToWavBytes_missingArguments_returnsError() {
+        val plugin = AudioDecoderPlugin()
+
+        val call = MethodCall("convertToWavBytes", mapOf("formatHint" to "mp3"))
+        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
+        plugin.onMethodCall(call, mockResult)
+
+        Mockito.verify(mockResult).error(
+            Mockito.eq("INVALID_ARGUMENTS"),
+            Mockito.eq("inputData and formatHint are required"),
+            Mockito.isNull()
+        )
+    }
+
+    @Test
+    fun onMethodCall_convertToM4aBytes_missingArguments_returnsError() {
+        val plugin = AudioDecoderPlugin()
+
+        val call = MethodCall("convertToM4aBytes", mapOf("formatHint" to "wav"))
+        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
+        plugin.onMethodCall(call, mockResult)
+
+        Mockito.verify(mockResult).error(
+            Mockito.eq("INVALID_ARGUMENTS"),
+            Mockito.eq("inputData and formatHint are required"),
+            Mockito.isNull()
+        )
+    }
+
+    @Test
+    fun onMethodCall_getAudioInfoBytes_missingArguments_returnsError() {
+        val plugin = AudioDecoderPlugin()
+
+        val call = MethodCall("getAudioInfoBytes", mapOf<String, Any>())
+        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
+        plugin.onMethodCall(call, mockResult)
+
+        Mockito.verify(mockResult).error(
+            Mockito.eq("INVALID_ARGUMENTS"),
+            Mockito.eq("inputData and formatHint are required"),
+            Mockito.isNull()
+        )
+    }
+
+    @Test
+    fun onMethodCall_trimAudioBytes_missingArguments_returnsError() {
+        val plugin = AudioDecoderPlugin()
+
+        val call = MethodCall("trimAudioBytes", mapOf("inputData" to ByteArray(1), "formatHint" to "mp3"))
+        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
+        plugin.onMethodCall(call, mockResult)
+
+        Mockito.verify(mockResult).error(
+            Mockito.eq("INVALID_ARGUMENTS"),
+            Mockito.eq("inputData, formatHint, startMs and endMs are required"),
+            Mockito.isNull()
+        )
+    }
+
+    @Test
+    fun onMethodCall_getWaveformBytes_missingArguments_returnsError() {
+        val plugin = AudioDecoderPlugin()
+
+        val call = MethodCall("getWaveformBytes", mapOf("inputData" to ByteArray(1)))
+        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
+        plugin.onMethodCall(call, mockResult)
+
+        Mockito.verify(mockResult).error(
+            Mockito.eq("INVALID_ARGUMENTS"),
+            Mockito.eq("inputData, formatHint and numberOfSamples are required"),
+            Mockito.isNull()
+        )
     }
 }

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -44,3 +44,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Large benchmark assets (provide your own, see integration_test/benchmark_test.dart)
+assets/test_large.*

--- a/example/integration_test/benchmark_test.dart
+++ b/example/integration_test/benchmark_test.dart
@@ -1,0 +1,142 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:audio_decoder/audio_decoder.dart';
+
+/// Benchmark test that measures conversion speed for large audio files.
+///
+/// ## Setup
+///
+/// 1. Place large audio files in `example/assets/`:
+///    - `test_large.mp3` (e.g. 5-10 min, ~10-20 MB)
+///    - `test_large.m4a` (same content, AAC encoded)
+///    - `test_large.wav` (same content, uncompressed PCM)
+///
+/// 2. Uncomment the `test_large.*` entries in `example/pubspec.yaml`:
+///    ```yaml
+///    assets:
+///      - assets/test_large.m4a
+///      - assets/test_large.mp3
+///      - assets/test_large.wav
+///    ```
+///
+/// 3. Run the benchmark:
+///    ```sh
+///    cd example
+///    flutter test integration_test/benchmark_test.dart -d <device-id>
+///    ```
+///
+/// Results are printed to stdout during the test run.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late String mp3Path;
+  late String m4aPath;
+  late String wavPath;
+  final results = <String>[];
+
+  setUpAll(() async {
+    tempDir = Directory.systemTemp.createTempSync('audio_decoder_bench_');
+
+    // Copy assets to temp dir once (not timed).
+    mp3Path = await _copyAsset('test_large.mp3', tempDir);
+    m4aPath = await _copyAsset('test_large.m4a', tempDir);
+    wavPath = await _copyAsset('test_large.wav', tempDir);
+  });
+
+  tearDownAll(() {
+    if (tempDir.existsSync()) {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  String outputPath(String name, String ext) =>
+      '${tempDir.path}/${name}_output.$ext';
+
+  void record(String label, int ms, int outputBytes) {
+    final mb = (outputBytes / 1024 / 1024).toStringAsFixed(1);
+    final line = '$label: $ms ms (output: $mb MB)';
+    results.add(line);
+    // ignore: avoid_print
+    print(line);
+  }
+
+  // ── Benchmark: convertToWav (default, no params) ───────────────────
+
+  group('Benchmark: convertToWav (default)', () {
+    testWidgets('MP3 → WAV', (WidgetTester tester) async {
+      final out = outputPath('bench_mp3', 'wav');
+
+      final sw = Stopwatch()..start();
+      await AudioDecoder.convertToWav(mp3Path, out);
+      sw.stop();
+
+      final size = await File(out).length();
+      record('MP3 → WAV (default)', sw.elapsedMilliseconds, size);
+    });
+
+    testWidgets('M4A → WAV', (WidgetTester tester) async {
+      final out = outputPath('bench_m4a', 'wav');
+
+      final sw = Stopwatch()..start();
+      await AudioDecoder.convertToWav(m4aPath, out);
+      sw.stop();
+
+      final size = await File(out).length();
+      record('M4A → WAV (default)', sw.elapsedMilliseconds, size);
+    });
+  });
+
+  // ── Benchmark: streaming path (channel/bitdepth only) ──────────────
+
+  group('Benchmark: streaming path', () {
+    testWidgets('MP3 → WAV mono', (WidgetTester tester) async {
+      final out = outputPath('bench_stream_mono', 'wav');
+
+      final sw = Stopwatch()..start();
+      await AudioDecoder.convertToWav(mp3Path, out, channels: 1);
+      sw.stop();
+
+      final size = await File(out).length();
+      record('MP3 → WAV (mono)', sw.elapsedMilliseconds, size);
+    });
+
+    testWidgets('MP3 → WAV 24bit', (WidgetTester tester) async {
+      final out = outputPath('bench_stream_24bit', 'wav');
+
+      final sw = Stopwatch()..start();
+      await AudioDecoder.convertToWav(mp3Path, out, bitDepth: 24);
+      sw.stop();
+
+      final size = await File(out).length();
+      record('MP3 → WAV (24bit)', sw.elapsedMilliseconds, size);
+    });
+  });
+
+  // ── Benchmark: convertToM4a ────────────────────────────────────────
+
+  group('Benchmark: convertToM4a', () {
+    testWidgets('WAV → M4A', (WidgetTester tester) async {
+      final out = outputPath('bench_wav_m4a', 'm4a');
+
+      final sw = Stopwatch()..start();
+      await AudioDecoder.convertToM4a(wavPath, out);
+      sw.stop();
+
+      final size = await File(out).length();
+      record('WAV → M4A', sw.elapsedMilliseconds, size);
+    });
+  });
+}
+
+/// Copy a bundled asset to [dir] and return the file path.
+Future<String> _copyAsset(String name, Directory dir) async {
+  final data = await rootBundle.load('assets/$name');
+  final file = File('${dir.path}/$name');
+  await file.writeAsBytes(data.buffer.asUint8List());
+  return file.path;
+}

--- a/example/integration_test/benchmark_test.dart
+++ b/example/integration_test/benchmark_test.dart
@@ -8,7 +8,8 @@ import 'package:audio_decoder/audio_decoder.dart';
 
 /// Benchmark test that measures conversion speed for large audio files.
 ///
-/// ## Setup
+/// These tests are **skipped by default** unless the large test assets are
+/// bundled. To run them:
 ///
 /// 1. Place large audio files in `example/assets/`:
 ///    - `test_large.mp3` (e.g. 5-10 min, ~10-20 MB)
@@ -37,15 +38,22 @@ void main() {
   late String mp3Path;
   late String m4aPath;
   late String wavPath;
+  var assetsAvailable = false;
   final results = <String>[];
 
   setUpAll(() async {
     tempDir = Directory.systemTemp.createTempSync('audio_decoder_bench_');
 
-    // Copy assets to temp dir once (not timed).
-    mp3Path = await _copyAsset('test_large.mp3', tempDir);
-    m4aPath = await _copyAsset('test_large.m4a', tempDir);
-    wavPath = await _copyAsset('test_large.wav', tempDir);
+    // Try loading the large assets. If they are not bundled, all tests
+    // in this file will be skipped gracefully.
+    try {
+      mp3Path = await _copyAsset('test_large.mp3', tempDir);
+      m4aPath = await _copyAsset('test_large.m4a', tempDir);
+      wavPath = await _copyAsset('test_large.wav', tempDir);
+      assetsAvailable = true;
+    } catch (_) {
+      // Assets not bundled — tests will be skipped.
+    }
   });
 
   tearDownAll(() {
@@ -69,6 +77,10 @@ void main() {
 
   group('Benchmark: convertToWav (default)', () {
     testWidgets('MP3 → WAV', (WidgetTester tester) async {
+      if (!assetsAvailable) {
+        markTestSkipped('test_large.* assets not bundled');
+        return;
+      }
       final out = outputPath('bench_mp3', 'wav');
 
       final sw = Stopwatch()..start();
@@ -80,6 +92,10 @@ void main() {
     });
 
     testWidgets('M4A → WAV', (WidgetTester tester) async {
+      if (!assetsAvailable) {
+        markTestSkipped('test_large.* assets not bundled');
+        return;
+      }
       final out = outputPath('bench_m4a', 'wav');
 
       final sw = Stopwatch()..start();
@@ -95,6 +111,10 @@ void main() {
 
   group('Benchmark: streaming path', () {
     testWidgets('MP3 → WAV mono', (WidgetTester tester) async {
+      if (!assetsAvailable) {
+        markTestSkipped('test_large.* assets not bundled');
+        return;
+      }
       final out = outputPath('bench_stream_mono', 'wav');
 
       final sw = Stopwatch()..start();
@@ -106,6 +126,10 @@ void main() {
     });
 
     testWidgets('MP3 → WAV 24bit', (WidgetTester tester) async {
+      if (!assetsAvailable) {
+        markTestSkipped('test_large.* assets not bundled');
+        return;
+      }
       final out = outputPath('bench_stream_24bit', 'wav');
 
       final sw = Stopwatch()..start();
@@ -121,6 +145,10 @@ void main() {
 
   group('Benchmark: convertToM4a', () {
     testWidgets('WAV → M4A', (WidgetTester tester) async {
+      if (!assetsAvailable) {
+        markTestSkipped('test_large.* assets not bundled');
+        return;
+      }
       final out = outputPath('bench_wav_m4a', 'm4a');
 
       final sw = Stopwatch()..start();

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -57,6 +57,10 @@ flutter:
     - assets/test_tone.m4a
     - assets/test_tone.mp3
     - assets/test_tone.wav
+    # Uncomment below to run benchmark_test.dart (see that file for setup):
+    # - assets/test_large.m4a
+    # - assets/test_large.mp3
+    # - assets/test_large.wav
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/to/resolution-aware-images


### PR DESCRIPTION
## Summary
- Writes decoded PCM chunks directly to disk via `RandomAccessFile` instead of accumulating all data in a `ByteArrayOutputStream` before writing
- Uses a placeholder WAV header that is updated with the actual data size after decoding completes
- Falls back to the original buffered approach when resampling is requested, since the linear interpolation algorithm requires the full PCM buffer

## Memory impact
| Scenario | Before | After |
|----------|--------|-------|
| Standard conversion (no resampling) | ~2x decoded PCM size (~80 MB for a 10 MB MP3) | ~buffer size (a few KB) |
| With resampling | ~2x decoded PCM size | Unchanged (buffered fallback) |

## Benchmark results

Tested on Android emulator (Medium_Phone, API 36, arm64-v8a, ~192 MB heap limit) with a ~10 min MP3 (16 MB compressed → ~119 MB PCM).

### `main` branch (buffered)

| Test | Result |
|------|--------|
| MP3 → WAV | **OOM CRASH** |

```
java.lang.OutOfMemoryError: Failed to allocate a 204341264 byte allocation
  with 25165824 free bytes and 92MB until OOM
    at java.io.ByteArrayOutputStream.grow(ByteArrayOutputStream.java:120)
    at AudioDecoderPlugin.performConversion(AudioDecoderPlugin.kt:368)
```

The old code buffers all decoded PCM (~195 MB) in a `ByteArrayOutputStream` before writing to disk, exceeding the heap limit.

### This branch (streaming)

| Test | Time | Output |
|------|------|--------|
| MP3 → WAV (default) | 24.0 s | 119.2 MB |
| M4A → WAV (default) | 43.5 s | 119.2 MB |
| MP3 → WAV (mono) | 21.9 s | 59.6 MB |
| MP3 → WAV (24-bit) | 22.6 s | 178.7 MB |
| WAV → M4A | 292.8 s | 10.9 MB |

All 5 conversions completed successfully with no memory issues. The streaming approach writes PCM chunks directly to disk, keeping memory usage independent of file size.

## Test plan
- [x] Run existing unit tests (`flutter test`)
- [x] Convert a large audio file to WAV on Android and verify output plays correctly
- [x] Convert with channel conversion (e.g. stereo to mono) and verify output
- [x] Convert with bit depth change (e.g. 16-bit to 24-bit) and verify output
- [x] Convert with resampling (e.g. 44100 to 22050) to exercise the buffered fallback path
- [x] Run all 23 integration tests on Android emulator

Closes #14