### PR TITLE
Stream decoded PCM chunks directly to disk for iOS/macOS

### DIFF
--- a/ios/Classes/AudioDecoderPlugin.swift
+++ b/ios/Classes/AudioDecoderPlugin.swift
@@ -5,6 +5,8 @@ import AVFoundation
 public class AudioDecoderPlugin: NSObject, FlutterPlugin {
     /// Standard RIFF/WAV header size in bytes (no extra chunks).
     private static let wavHeaderSize = 44
+    /// Maximum PCM data size for a valid WAV file (~4 GB).
+    private static let maxWavDataSize: Int64 = 0xFFFF_FFFF - 36
 
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(
@@ -196,31 +198,6 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
         trackOutput.alwaysCopiesSampleData = false
         assetReader.add(trackOutput)
 
-        guard assetReader.startReading() else {
-            throw NSError(domain: "AudioDecoder", code: 3,
-                          userInfo: [NSLocalizedDescriptionKey:
-                                        "AVAssetReader failed to start: \(assetReader.error?.localizedDescription ?? "unknown")"])
-        }
-
-        var pcmData = Data()
-        while let sampleBuffer = trackOutput.copyNextSampleBuffer() {
-            if let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) {
-                let length = CMBlockBufferGetDataLength(blockBuffer)
-                var data = Data(count: length)
-                _ = data.withUnsafeMutableBytes { ptr in
-                    CMBlockBufferCopyDataBytes(blockBuffer, atOffset: 0, dataLength: length,
-                                               destination: ptr.baseAddress!)
-                }
-                pcmData.append(data)
-            }
-        }
-
-        if assetReader.status == .failed {
-            throw NSError(domain: "AudioDecoder", code: 4,
-                          userInfo: [NSLocalizedDescriptionKey:
-                                        "AVAssetReader failed: \(assetReader.error?.localizedDescription ?? "unknown")"])
-        }
-
         guard let formatDesc = audioTrack.formatDescriptions.first else {
             throw NSError(domain: "AudioDecoder", code: 5,
                           userInfo: [NSLocalizedDescriptionKey: "No format description available"])
@@ -233,8 +210,57 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
         let sampleRate = targetSampleRate ?? Int(asbd.mSampleRate)
         let channels = targetChannels ?? Int(asbd.mChannelsPerFrame)
 
-        try writeWavFile(outputURL: outputURL, pcmData: pcmData,
-                         sampleRate: sampleRate, channels: channels, bitsPerSample: bitsPerSample)
+        guard assetReader.startReading() else {
+            throw NSError(domain: "AudioDecoder", code: 3,
+                          userInfo: [NSLocalizedDescriptionKey:
+                                        "AVAssetReader failed to start: \(assetReader.error?.localizedDescription ?? "unknown")"])
+        }
+
+        guard fm.createFile(atPath: outputPath, contents: nil) else {
+            throw NSError(domain: "AudioDecoder", code: 6,
+                          userInfo: [NSLocalizedDescriptionKey: "Cannot create output file at \(outputPath)"])
+        }
+        let fileHandle = try FileHandle(forWritingTo: outputURL)
+        do {
+            // Write placeholder WAV header (will be updated after decoding)
+            fileHandle.write(buildWavHeader(pcmDataSize: 0,
+                                            sampleRate: sampleRate, channels: channels, bitsPerSample: bitsPerSample))
+
+            var totalPcmBytes: Int64 = 0
+            while let sampleBuffer = trackOutput.copyNextSampleBuffer() {
+                if let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) {
+                    let length = CMBlockBufferGetDataLength(blockBuffer)
+                    var chunk = Data(count: length)
+                    _ = chunk.withUnsafeMutableBytes { ptr in
+                        CMBlockBufferCopyDataBytes(blockBuffer, atOffset: 0, dataLength: length,
+                                                   destination: ptr.baseAddress!)
+                    }
+                    fileHandle.write(chunk)
+                    totalPcmBytes += Int64(length)
+                    if totalPcmBytes > AudioDecoderPlugin.maxWavDataSize {
+                        throw NSError(domain: "AudioDecoder", code: 7,
+                                      userInfo: [NSLocalizedDescriptionKey:
+                                                    "WAV output exceeds maximum size (~4 GB). Consider splitting the audio into shorter segments."])
+                    }
+                }
+            }
+
+            if assetReader.status == .failed {
+                throw NSError(domain: "AudioDecoder", code: 4,
+                              userInfo: [NSLocalizedDescriptionKey:
+                                            "AVAssetReader failed: \(assetReader.error?.localizedDescription ?? "unknown")"])
+            }
+
+            // Seek back and write the final WAV header with the actual data size.
+            fileHandle.seek(toFileOffset: 0)
+            fileHandle.write(buildWavHeader(pcmDataSize: Int(totalPcmBytes),
+                                            sampleRate: sampleRate, channels: channels, bitsPerSample: bitsPerSample))
+            fileHandle.closeFile()
+        } catch {
+            fileHandle.closeFile()
+            try? fm.removeItem(at: outputURL)
+            throw error
+        }
     }
 
     // MARK: - Convert to M4A
@@ -437,7 +463,6 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
                               userInfo: [NSLocalizedDescriptionKey: "Trim export failed"])
             }
         } else {
-            // Decode trimmed range to PCM and write WAV
             guard let assetReader = try? AVAssetReader(asset: asset) else {
                 throw NSError(domain: "AudioDecoder", code: 32,
                               userInfo: [NSLocalizedDescriptionKey: "Cannot create AVAssetReader"])
@@ -462,29 +487,6 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
             trackOutput.alwaysCopiesSampleData = false
             assetReader.add(trackOutput)
 
-            guard assetReader.startReading() else {
-                throw NSError(domain: "AudioDecoder", code: 34,
-                              userInfo: [NSLocalizedDescriptionKey: "AVAssetReader failed to start"])
-            }
-
-            var pcmData = Data()
-            while let sampleBuffer = trackOutput.copyNextSampleBuffer() {
-                if let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) {
-                    let length = CMBlockBufferGetDataLength(blockBuffer)
-                    var data = Data(count: length)
-                    _ = data.withUnsafeMutableBytes { ptr in
-                        CMBlockBufferCopyDataBytes(blockBuffer, atOffset: 0, dataLength: length,
-                                                   destination: ptr.baseAddress!)
-                    }
-                    pcmData.append(data)
-                }
-            }
-
-            if assetReader.status == .failed {
-                throw NSError(domain: "AudioDecoder", code: 35,
-                              userInfo: [NSLocalizedDescriptionKey: "AVAssetReader failed"])
-            }
-
             guard let formatDesc = audioTrack.formatDescriptions.first else {
                 throw NSError(domain: "AudioDecoder", code: 36,
                               userInfo: [NSLocalizedDescriptionKey: "No format description available"])
@@ -497,8 +499,53 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
             let sampleRate = Int(asbd.mSampleRate)
             let channels = Int(asbd.mChannelsPerFrame)
 
-            try writeWavFile(outputURL: outputURL, pcmData: pcmData,
-                             sampleRate: sampleRate, channels: channels, bitsPerSample: 16)
+            guard assetReader.startReading() else {
+                throw NSError(domain: "AudioDecoder", code: 34,
+                              userInfo: [NSLocalizedDescriptionKey: "AVAssetReader failed to start"])
+            }
+
+            guard fm.createFile(atPath: outputPath, contents: nil) else {
+                throw NSError(domain: "AudioDecoder", code: 37,
+                              userInfo: [NSLocalizedDescriptionKey: "Cannot create output file at \(outputPath)"])
+            }
+            let fileHandle = try FileHandle(forWritingTo: outputURL)
+            do {
+                fileHandle.write(buildWavHeader(pcmDataSize: 0,
+                                                sampleRate: sampleRate, channels: channels, bitsPerSample: 16))
+
+                var totalPcmBytes: Int64 = 0
+                while let sampleBuffer = trackOutput.copyNextSampleBuffer() {
+                    if let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) {
+                        let length = CMBlockBufferGetDataLength(blockBuffer)
+                        var chunk = Data(count: length)
+                        _ = chunk.withUnsafeMutableBytes { ptr in
+                            CMBlockBufferCopyDataBytes(blockBuffer, atOffset: 0, dataLength: length,
+                                                       destination: ptr.baseAddress!)
+                        }
+                        fileHandle.write(chunk)
+                        totalPcmBytes += Int64(length)
+                        if totalPcmBytes > AudioDecoderPlugin.maxWavDataSize {
+                            throw NSError(domain: "AudioDecoder", code: 38,
+                                          userInfo: [NSLocalizedDescriptionKey:
+                                                        "WAV output exceeds maximum size (~4 GB). Consider splitting the audio into shorter segments."])
+                        }
+                    }
+                }
+
+                if assetReader.status == .failed {
+                    throw NSError(domain: "AudioDecoder", code: 35,
+                                  userInfo: [NSLocalizedDescriptionKey: "AVAssetReader failed"])
+                }
+
+                fileHandle.seek(toFileOffset: 0)
+                fileHandle.write(buildWavHeader(pcmDataSize: Int(totalPcmBytes),
+                                                sampleRate: sampleRate, channels: channels, bitsPerSample: 16))
+                fileHandle.closeFile()
+            } catch {
+                fileHandle.closeFile()
+                try? fm.removeItem(at: outputURL)
+                throw error
+            }
         }
     }
 
@@ -735,30 +782,27 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    // MARK: - WAV writing helper
+    // MARK: - WAV header helper
 
-    private func writeWavFile(outputURL: URL, pcmData: Data,
-                              sampleRate: Int, channels: Int, bitsPerSample: Int) throws {
+    private func buildWavHeader(pcmDataSize: Int, sampleRate: Int, channels: Int, bitsPerSample: Int) -> Data {
         let byteRate = sampleRate * channels * (bitsPerSample / 8)
         let blockAlign = channels * (bitsPerSample / 8)
 
-        var wavData = Data()
-        wavData.append(contentsOf: [UInt8]("RIFF".utf8))
-        wavData.append(UInt32(36 + pcmData.count).littleEndianBytes)
-        wavData.append(contentsOf: [UInt8]("WAVE".utf8))
-        wavData.append(contentsOf: [UInt8]("fmt ".utf8))
-        wavData.append(UInt32(16).littleEndianBytes)
-        wavData.append(UInt16(1).littleEndianBytes)
-        wavData.append(UInt16(channels).littleEndianBytes)
-        wavData.append(UInt32(sampleRate).littleEndianBytes)
-        wavData.append(UInt32(byteRate).littleEndianBytes)
-        wavData.append(UInt16(blockAlign).littleEndianBytes)
-        wavData.append(UInt16(bitsPerSample).littleEndianBytes)
-        wavData.append(contentsOf: [UInt8]("data".utf8))
-        wavData.append(UInt32(pcmData.count).littleEndianBytes)
-        wavData.append(pcmData)
-
-        try wavData.write(to: outputURL)
+        var header = Data()
+        header.append(contentsOf: [UInt8]("RIFF".utf8))
+        header.append(UInt32(36 + pcmDataSize).littleEndianBytes)
+        header.append(contentsOf: [UInt8]("WAVE".utf8))
+        header.append(contentsOf: [UInt8]("fmt ".utf8))
+        header.append(UInt32(16).littleEndianBytes)
+        header.append(UInt16(1).littleEndianBytes)
+        header.append(UInt16(channels).littleEndianBytes)
+        header.append(UInt32(sampleRate).littleEndianBytes)
+        header.append(UInt32(byteRate).littleEndianBytes)
+        header.append(UInt16(blockAlign).littleEndianBytes)
+        header.append(UInt16(bitsPerSample).littleEndianBytes)
+        header.append(contentsOf: [UInt8]("data".utf8))
+        header.append(UInt32(pcmDataSize).littleEndianBytes)
+        return header
     }
 }
 

--- a/macos/Classes/AudioDecoderPlugin.swift
+++ b/macos/Classes/AudioDecoderPlugin.swift
@@ -5,6 +5,8 @@ import AVFoundation
 public class AudioDecoderPlugin: NSObject, FlutterPlugin {
     /// Standard RIFF/WAV header size in bytes (no extra chunks).
     private static let wavHeaderSize = 44
+    /// Maximum PCM data size for a valid WAV file (~4 GB).
+    private static let maxWavDataSize: Int64 = 0xFFFF_FFFF - 36
 
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(
@@ -196,31 +198,6 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
         trackOutput.alwaysCopiesSampleData = false
         assetReader.add(trackOutput)
 
-        guard assetReader.startReading() else {
-            throw NSError(domain: "AudioDecoder", code: 3,
-                          userInfo: [NSLocalizedDescriptionKey:
-                                        "AVAssetReader failed to start: \(assetReader.error?.localizedDescription ?? "unknown")"])
-        }
-
-        var pcmData = Data()
-        while let sampleBuffer = trackOutput.copyNextSampleBuffer() {
-            if let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) {
-                let length = CMBlockBufferGetDataLength(blockBuffer)
-                var data = Data(count: length)
-                _ = data.withUnsafeMutableBytes { ptr in
-                    CMBlockBufferCopyDataBytes(blockBuffer, atOffset: 0, dataLength: length,
-                                               destination: ptr.baseAddress!)
-                }
-                pcmData.append(data)
-            }
-        }
-
-        if assetReader.status == .failed {
-            throw NSError(domain: "AudioDecoder", code: 4,
-                          userInfo: [NSLocalizedDescriptionKey:
-                                        "AVAssetReader failed: \(assetReader.error?.localizedDescription ?? "unknown")"])
-        }
-
         guard let formatDesc = audioTrack.formatDescriptions.first else {
             throw NSError(domain: "AudioDecoder", code: 5,
                           userInfo: [NSLocalizedDescriptionKey: "No format description available"])
@@ -233,8 +210,57 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
         let sampleRate = targetSampleRate ?? Int(asbd.mSampleRate)
         let channels = targetChannels ?? Int(asbd.mChannelsPerFrame)
 
-        try writeWavFile(outputURL: outputURL, pcmData: pcmData,
-                         sampleRate: sampleRate, channels: channels, bitsPerSample: bitsPerSample)
+        guard assetReader.startReading() else {
+            throw NSError(domain: "AudioDecoder", code: 3,
+                          userInfo: [NSLocalizedDescriptionKey:
+                                        "AVAssetReader failed to start: \(assetReader.error?.localizedDescription ?? "unknown")"])
+        }
+
+        guard fm.createFile(atPath: outputPath, contents: nil) else {
+            throw NSError(domain: "AudioDecoder", code: 6,
+                          userInfo: [NSLocalizedDescriptionKey: "Cannot create output file at \(outputPath)"])
+        }
+        let fileHandle = try FileHandle(forWritingTo: outputURL)
+        do {
+            // Write placeholder WAV header (will be updated after decoding)
+            fileHandle.write(buildWavHeader(pcmDataSize: 0,
+                                            sampleRate: sampleRate, channels: channels, bitsPerSample: bitsPerSample))
+
+            var totalPcmBytes: Int64 = 0
+            while let sampleBuffer = trackOutput.copyNextSampleBuffer() {
+                if let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) {
+                    let length = CMBlockBufferGetDataLength(blockBuffer)
+                    var chunk = Data(count: length)
+                    _ = chunk.withUnsafeMutableBytes { ptr in
+                        CMBlockBufferCopyDataBytes(blockBuffer, atOffset: 0, dataLength: length,
+                                                   destination: ptr.baseAddress!)
+                    }
+                    fileHandle.write(chunk)
+                    totalPcmBytes += Int64(length)
+                    if totalPcmBytes > AudioDecoderPlugin.maxWavDataSize {
+                        throw NSError(domain: "AudioDecoder", code: 7,
+                                      userInfo: [NSLocalizedDescriptionKey:
+                                                    "WAV output exceeds maximum size (~4 GB). Consider splitting the audio into shorter segments."])
+                    }
+                }
+            }
+
+            if assetReader.status == .failed {
+                throw NSError(domain: "AudioDecoder", code: 4,
+                              userInfo: [NSLocalizedDescriptionKey:
+                                            "AVAssetReader failed: \(assetReader.error?.localizedDescription ?? "unknown")"])
+            }
+
+            // Seek back and write the final WAV header with the actual data size.
+            fileHandle.seek(toFileOffset: 0)
+            fileHandle.write(buildWavHeader(pcmDataSize: Int(totalPcmBytes),
+                                            sampleRate: sampleRate, channels: channels, bitsPerSample: bitsPerSample))
+            fileHandle.closeFile()
+        } catch {
+            fileHandle.closeFile()
+            try? fm.removeItem(at: outputURL)
+            throw error
+        }
     }
 
     // MARK: - Convert to M4A
@@ -460,29 +486,6 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
             trackOutput.alwaysCopiesSampleData = false
             assetReader.add(trackOutput)
 
-            guard assetReader.startReading() else {
-                throw NSError(domain: "AudioDecoder", code: 34,
-                              userInfo: [NSLocalizedDescriptionKey: "AVAssetReader failed to start"])
-            }
-
-            var pcmData = Data()
-            while let sampleBuffer = trackOutput.copyNextSampleBuffer() {
-                if let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) {
-                    let length = CMBlockBufferGetDataLength(blockBuffer)
-                    var data = Data(count: length)
-                    _ = data.withUnsafeMutableBytes { ptr in
-                        CMBlockBufferCopyDataBytes(blockBuffer, atOffset: 0, dataLength: length,
-                                                   destination: ptr.baseAddress!)
-                    }
-                    pcmData.append(data)
-                }
-            }
-
-            if assetReader.status == .failed {
-                throw NSError(domain: "AudioDecoder", code: 35,
-                              userInfo: [NSLocalizedDescriptionKey: "AVAssetReader failed"])
-            }
-
             guard let formatDesc = audioTrack.formatDescriptions.first else {
                 throw NSError(domain: "AudioDecoder", code: 36,
                               userInfo: [NSLocalizedDescriptionKey: "No format description available"])
@@ -495,8 +498,53 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
             let sampleRate = Int(asbd.mSampleRate)
             let channels = Int(asbd.mChannelsPerFrame)
 
-            try writeWavFile(outputURL: outputURL, pcmData: pcmData,
-                             sampleRate: sampleRate, channels: channels, bitsPerSample: 16)
+            guard assetReader.startReading() else {
+                throw NSError(domain: "AudioDecoder", code: 34,
+                              userInfo: [NSLocalizedDescriptionKey: "AVAssetReader failed to start"])
+            }
+
+            guard fm.createFile(atPath: outputPath, contents: nil) else {
+                throw NSError(domain: "AudioDecoder", code: 37,
+                              userInfo: [NSLocalizedDescriptionKey: "Cannot create output file at \(outputPath)"])
+            }
+            let fileHandle = try FileHandle(forWritingTo: outputURL)
+            do {
+                fileHandle.write(buildWavHeader(pcmDataSize: 0,
+                                                sampleRate: sampleRate, channels: channels, bitsPerSample: 16))
+
+                var totalPcmBytes: Int64 = 0
+                while let sampleBuffer = trackOutput.copyNextSampleBuffer() {
+                    if let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) {
+                        let length = CMBlockBufferGetDataLength(blockBuffer)
+                        var chunk = Data(count: length)
+                        _ = chunk.withUnsafeMutableBytes { ptr in
+                            CMBlockBufferCopyDataBytes(blockBuffer, atOffset: 0, dataLength: length,
+                                                       destination: ptr.baseAddress!)
+                        }
+                        fileHandle.write(chunk)
+                        totalPcmBytes += Int64(length)
+                        if totalPcmBytes > AudioDecoderPlugin.maxWavDataSize {
+                            throw NSError(domain: "AudioDecoder", code: 38,
+                                          userInfo: [NSLocalizedDescriptionKey:
+                                                        "WAV output exceeds maximum size (~4 GB). Consider splitting the audio into shorter segments."])
+                        }
+                    }
+                }
+
+                if assetReader.status == .failed {
+                    throw NSError(domain: "AudioDecoder", code: 35,
+                                  userInfo: [NSLocalizedDescriptionKey: "AVAssetReader failed"])
+                }
+
+                fileHandle.seek(toFileOffset: 0)
+                fileHandle.write(buildWavHeader(pcmDataSize: Int(totalPcmBytes),
+                                                sampleRate: sampleRate, channels: channels, bitsPerSample: 16))
+                fileHandle.closeFile()
+            } catch {
+                fileHandle.closeFile()
+                try? fm.removeItem(at: outputURL)
+                throw error
+            }
         }
     }
 
@@ -729,30 +777,27 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    // MARK: - WAV writing helper
+    // MARK: - WAV header helper
 
-    private func writeWavFile(outputURL: URL, pcmData: Data,
-                              sampleRate: Int, channels: Int, bitsPerSample: Int) throws {
+    private func buildWavHeader(pcmDataSize: Int, sampleRate: Int, channels: Int, bitsPerSample: Int) -> Data {
         let byteRate = sampleRate * channels * (bitsPerSample / 8)
         let blockAlign = channels * (bitsPerSample / 8)
 
-        var wavData = Data()
-        wavData.append(contentsOf: [UInt8]("RIFF".utf8))
-        wavData.append(UInt32(36 + pcmData.count).littleEndianBytes)
-        wavData.append(contentsOf: [UInt8]("WAVE".utf8))
-        wavData.append(contentsOf: [UInt8]("fmt ".utf8))
-        wavData.append(UInt32(16).littleEndianBytes)
-        wavData.append(UInt16(1).littleEndianBytes)
-        wavData.append(UInt16(channels).littleEndianBytes)
-        wavData.append(UInt32(sampleRate).littleEndianBytes)
-        wavData.append(UInt32(byteRate).littleEndianBytes)
-        wavData.append(UInt16(blockAlign).littleEndianBytes)
-        wavData.append(UInt16(bitsPerSample).littleEndianBytes)
-        wavData.append(contentsOf: [UInt8]("data".utf8))
-        wavData.append(UInt32(pcmData.count).littleEndianBytes)
-        wavData.append(pcmData)
-
-        try wavData.write(to: outputURL)
+        var header = Data()
+        header.append(contentsOf: [UInt8]("RIFF".utf8))
+        header.append(UInt32(36 + pcmDataSize).littleEndianBytes)
+        header.append(contentsOf: [UInt8]("WAVE".utf8))
+        header.append(contentsOf: [UInt8]("fmt ".utf8))
+        header.append(UInt32(16).littleEndianBytes)
+        header.append(UInt16(1).littleEndianBytes)
+        header.append(UInt16(channels).littleEndianBytes)
+        header.append(UInt32(sampleRate).littleEndianBytes)
+        header.append(UInt32(byteRate).littleEndianBytes)
+        header.append(UInt16(blockAlign).littleEndianBytes)
+        header.append(UInt16(bitsPerSample).littleEndianBytes)
+        header.append(contentsOf: [UInt8]("data".utf8))
+        header.append(UInt32(pcmDataSize).littleEndianBytes)
+        return header
     }
 }
 

--- a/macos/Classes/AudioDecoderPlugin.swift
+++ b/macos/Classes/AudioDecoderPlugin.swift
@@ -216,51 +216,11 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
                                         "AVAssetReader failed to start: \(assetReader.error?.localizedDescription ?? "unknown")"])
         }
 
-        guard fm.createFile(atPath: outputPath, contents: nil) else {
-            throw NSError(domain: "AudioDecoder", code: 6,
-                          userInfo: [NSLocalizedDescriptionKey: "Cannot create output file at \(outputPath)"])
-        }
-        let fileHandle = try FileHandle(forWritingTo: outputURL)
-        do {
-            // Write placeholder WAV header (will be updated after decoding)
-            fileHandle.write(buildWavHeader(pcmDataSize: 0,
-                                            sampleRate: sampleRate, channels: channels, bitsPerSample: bitsPerSample))
-
-            var totalPcmBytes: Int64 = 0
-            while let sampleBuffer = trackOutput.copyNextSampleBuffer() {
-                if let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) {
-                    let length = CMBlockBufferGetDataLength(blockBuffer)
-                    var chunk = Data(count: length)
-                    _ = chunk.withUnsafeMutableBytes { ptr in
-                        CMBlockBufferCopyDataBytes(blockBuffer, atOffset: 0, dataLength: length,
-                                                   destination: ptr.baseAddress!)
-                    }
-                    fileHandle.write(chunk)
-                    totalPcmBytes += Int64(length)
-                    if totalPcmBytes > AudioDecoderPlugin.maxWavDataSize {
-                        throw NSError(domain: "AudioDecoder", code: 7,
-                                      userInfo: [NSLocalizedDescriptionKey:
-                                                    "WAV output exceeds maximum size (~4 GB). Consider splitting the audio into shorter segments."])
-                    }
-                }
-            }
-
-            if assetReader.status == .failed {
-                throw NSError(domain: "AudioDecoder", code: 4,
-                              userInfo: [NSLocalizedDescriptionKey:
-                                            "AVAssetReader failed: \(assetReader.error?.localizedDescription ?? "unknown")"])
-            }
-
-            // Seek back and write the final WAV header with the actual data size.
-            fileHandle.seek(toFileOffset: 0)
-            fileHandle.write(buildWavHeader(pcmDataSize: Int(totalPcmBytes),
-                                            sampleRate: sampleRate, channels: channels, bitsPerSample: bitsPerSample))
-            fileHandle.closeFile()
-        } catch {
-            fileHandle.closeFile()
-            try? fm.removeItem(at: outputURL)
-            throw error
-        }
+        try streamPcmToWav(
+            assetReader: assetReader, trackOutput: trackOutput,
+            outputURL: outputURL, sampleRate: sampleRate, channels: channels,
+            bitsPerSample: bitsPerSample,
+            readerFailedCode: 4, overflowCode: 7, createFileFailedCode: 6)
     }
 
     // MARK: - Convert to M4A
@@ -503,48 +463,11 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
                               userInfo: [NSLocalizedDescriptionKey: "AVAssetReader failed to start"])
             }
 
-            guard fm.createFile(atPath: outputPath, contents: nil) else {
-                throw NSError(domain: "AudioDecoder", code: 37,
-                              userInfo: [NSLocalizedDescriptionKey: "Cannot create output file at \(outputPath)"])
-            }
-            let fileHandle = try FileHandle(forWritingTo: outputURL)
-            do {
-                fileHandle.write(buildWavHeader(pcmDataSize: 0,
-                                                sampleRate: sampleRate, channels: channels, bitsPerSample: 16))
-
-                var totalPcmBytes: Int64 = 0
-                while let sampleBuffer = trackOutput.copyNextSampleBuffer() {
-                    if let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) {
-                        let length = CMBlockBufferGetDataLength(blockBuffer)
-                        var chunk = Data(count: length)
-                        _ = chunk.withUnsafeMutableBytes { ptr in
-                            CMBlockBufferCopyDataBytes(blockBuffer, atOffset: 0, dataLength: length,
-                                                       destination: ptr.baseAddress!)
-                        }
-                        fileHandle.write(chunk)
-                        totalPcmBytes += Int64(length)
-                        if totalPcmBytes > AudioDecoderPlugin.maxWavDataSize {
-                            throw NSError(domain: "AudioDecoder", code: 38,
-                                          userInfo: [NSLocalizedDescriptionKey:
-                                                        "WAV output exceeds maximum size (~4 GB). Consider splitting the audio into shorter segments."])
-                        }
-                    }
-                }
-
-                if assetReader.status == .failed {
-                    throw NSError(domain: "AudioDecoder", code: 35,
-                                  userInfo: [NSLocalizedDescriptionKey: "AVAssetReader failed"])
-                }
-
-                fileHandle.seek(toFileOffset: 0)
-                fileHandle.write(buildWavHeader(pcmDataSize: Int(totalPcmBytes),
-                                                sampleRate: sampleRate, channels: channels, bitsPerSample: 16))
-                fileHandle.closeFile()
-            } catch {
-                fileHandle.closeFile()
-                try? fm.removeItem(at: outputURL)
-                throw error
-            }
+            try streamPcmToWav(
+                assetReader: assetReader, trackOutput: trackOutput,
+                outputURL: outputURL, sampleRate: sampleRate, channels: channels,
+                bitsPerSample: 16,
+                readerFailedCode: 35, overflowCode: 38, createFileFailedCode: 37)
         }
     }
 
@@ -777,7 +700,75 @@ public class AudioDecoderPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    // MARK: - WAV header helper
+    // MARK: - WAV streaming & header helpers
+
+    /// Streams decoded PCM chunks from an AVAssetReader to a WAV file on disk.
+    ///
+    /// The caller must have already called `assetReader.startReading()` before invoking this method.
+    private func streamPcmToWav(
+        assetReader: AVAssetReader,
+        trackOutput: AVAssetReaderTrackOutput,
+        outputURL: URL,
+        sampleRate: Int,
+        channels: Int,
+        bitsPerSample: Int,
+        readerFailedCode: Int,
+        overflowCode: Int,
+        createFileFailedCode: Int
+    ) throws {
+        let fm = FileManager.default
+        let outputPath = outputURL.path
+
+        guard fm.createFile(atPath: outputPath, contents: nil) else {
+            throw NSError(domain: "AudioDecoder", code: createFileFailedCode,
+                          userInfo: [NSLocalizedDescriptionKey: "Cannot create output file at \(outputPath)"])
+        }
+        let fileHandle = try FileHandle(forWritingTo: outputURL)
+        var success = false
+        defer {
+            try? fileHandle.close()
+            if !success {
+                try? fm.removeItem(at: outputURL)
+            }
+        }
+
+        // Write placeholder WAV header (will be updated after decoding)
+        fileHandle.write(buildWavHeader(pcmDataSize: 0,
+                                        sampleRate: sampleRate, channels: channels, bitsPerSample: bitsPerSample))
+
+        var totalPcmBytes: Int64 = 0
+        while let sampleBuffer = trackOutput.copyNextSampleBuffer() {
+            if let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) {
+                let length = CMBlockBufferGetDataLength(blockBuffer)
+                var chunk = Data(count: length)
+                _ = chunk.withUnsafeMutableBytes { ptr in
+                    CMBlockBufferCopyDataBytes(blockBuffer, atOffset: 0, dataLength: length,
+                                               destination: ptr.baseAddress!)
+                }
+                totalPcmBytes += Int64(length)
+                if totalPcmBytes > AudioDecoderPlugin.maxWavDataSize {
+                    throw NSError(domain: "AudioDecoder", code: overflowCode,
+                                  userInfo: [NSLocalizedDescriptionKey:
+                                                "WAV output exceeds maximum size (~4 GB). Consider splitting the audio into shorter segments."])
+                }
+                fileHandle.write(chunk)
+            }
+        }
+
+        if assetReader.status == .failed {
+            throw NSError(domain: "AudioDecoder", code: readerFailedCode,
+                          userInfo: [NSLocalizedDescriptionKey:
+                                        "AVAssetReader failed: \(assetReader.error?.localizedDescription ?? "unknown")"])
+        }
+
+        // Seek back and write the final WAV header with the actual data size.
+        // The Int cast is safe: totalPcmBytes is validated against maxWavDataSize (< 2^32),
+        // so the value always fits within Int on 64-bit Apple platforms.
+        fileHandle.seek(toFileOffset: 0)
+        fileHandle.write(buildWavHeader(pcmDataSize: Int(totalPcmBytes),
+                                        sampleRate: sampleRate, channels: channels, bitsPerSample: bitsPerSample))
+        success = true
+    }
 
     private func buildWavHeader(pcmDataSize: Int, sampleRate: Int, channels: Int, bitsPerSample: Int) -> Data {
         let byteRate = sampleRate * channels * (bitsPerSample / 8)

--- a/macos/audio_decoder.podspec
+++ b/macos/audio_decoder.podspec
@@ -24,7 +24,7 @@ A new Flutter plugin project.
 
   s.dependency 'FlutterMacOS'
 
-  s.platform = :osx, '10.13'
+  s.platform = :osx, '10.15'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'
 end


### PR DESCRIPTION
## Summary

- Replace in-memory PCM accumulation with streaming `FileHandle` writes in both `performConversion` and `performTrimAudio` on iOS and macOS
- Write a placeholder WAV header first, stream decoded chunks to disk, then seek back to update the header with the actual data size
- Add ~4 GB overflow guard (`maxWavDataSize`) consistent with the Android implementation from #14

## Test plan

- [x] All 23 macOS integration tests pass (including streaming path tests for channel/bit depth conversion and WAV header size validation)
- [x] All 54 Dart unit tests pass
- [ ] Manual verification on iOS simulator

Closes #18