### PR TITLE
Stream decoded PCM chunks directly to disk for Linux/Windows

### DIFF
--- a/windows/audio_decoder_plugin.cpp
+++ b/windows/audio_decoder_plugin.cpp
@@ -28,6 +28,9 @@
 /// Standard RIFF/WAV header size in bytes (no extra chunks).
 static constexpr size_t kWavHeaderSize = 44;
 
+/// Maximum PCM data size that fits in a standard WAV file (~4 GB).
+static constexpr int64_t kMaxWavDataSize = 0xFFFFFFFFL - 36;
+
 static std::wstring Utf8ToWide(const std::string& utf8) {
     if (utf8.empty()) return {};
     int size = MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, nullptr, 0);
@@ -428,8 +431,10 @@ void AudioDecoderPlugin::HandleMethodCall(
     }
 }
 
-AudioDecoderPlugin::PcmResult AudioDecoderPlugin::DecodeToPcm(
-    const std::string& inputPath, int64_t startMs, int64_t endMs,
+AudioDecoderPlugin::PcmInfo AudioDecoderPlugin::DecodeToPcmStream(
+    const std::string& inputPath,
+    const std::function<void(const uint8_t*, size_t)>& onChunk,
+    int64_t startMs, int64_t endMs,
     int targetSampleRate, int targetChannels, int targetBitDepth) {
 
     MFSession session;
@@ -445,13 +450,13 @@ AudioDecoderPlugin::PcmResult AudioDecoderPlugin::DecodeToPcm(
         throw std::runtime_error("Failed to create source reader for input file");
     }
 
-    int bitsPerSample = (targetBitDepth > 0) ? targetBitDepth : 16;
+    int bitsPerSampleHint = (targetBitDepth > 0) ? targetBitDepth : 16;
 
     IMFMediaType* pPartialType = nullptr;
     MFCreateMediaType(&pPartialType);
     pPartialType->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Audio);
     pPartialType->SetGUID(MF_MT_SUBTYPE, MFAudioFormat_PCM);
-    pPartialType->SetUINT32(MF_MT_AUDIO_BITS_PER_SAMPLE, bitsPerSample);
+    pPartialType->SetUINT32(MF_MT_AUDIO_BITS_PER_SAMPLE, bitsPerSampleHint);
     if (targetSampleRate > 0) {
         pPartialType->SetUINT32(MF_MT_AUDIO_SAMPLES_PER_SECOND, targetSampleRate);
     }
@@ -494,7 +499,6 @@ AudioDecoderPlugin::PcmResult AudioDecoderPlugin::DecodeToPcm(
 
     int64_t endHns = (endMs >= 0) ? endMs * 10000LL : -1;
 
-    std::vector<uint8_t> pcmData;
     while (true) {
         DWORD flags = 0;
         LONGLONG timestamp = 0;
@@ -522,7 +526,7 @@ AudioDecoderPlugin::PcmResult AudioDecoderPlugin::DecodeToPcm(
                 DWORD cbBuffer = 0;
                 hr = pBuffer->Lock(&pAudioData, nullptr, &cbBuffer);
                 if (SUCCEEDED(hr)) {
-                    pcmData.insert(pcmData.end(), pAudioData, pAudioData + cbBuffer);
+                    onChunk(pAudioData, cbBuffer);
                     pBuffer->Unlock();
                 }
                 pBuffer->Release();
@@ -532,33 +536,65 @@ AudioDecoderPlugin::PcmResult AudioDecoderPlugin::DecodeToPcm(
     }
     pReader->Release();
 
-    PcmResult res;
-    res.data = std::move(pcmData);
-    res.sampleRate = sampleRate;
-    res.channels = channels;
-    res.bitsPerSample = bitsPerSample;
-    return res;
+    PcmInfo info;
+    info.sampleRate = sampleRate;
+    info.channels = channels;
+    info.bitsPerSample = bitsPerSample;
+    return info;
+}
+
+AudioDecoderPlugin::PcmResult AudioDecoderPlugin::DecodeToPcm(
+    const std::string& inputPath, int64_t startMs, int64_t endMs,
+    int targetSampleRate, int targetChannels, int targetBitDepth) {
+
+    PcmResult result{};
+    auto info = DecodeToPcmStream(inputPath,
+        [&](const uint8_t* data, size_t size) {
+            result.data.insert(result.data.end(), data, data + size);
+        },
+        startMs, endMs, targetSampleRate, targetChannels, targetBitDepth);
+    result.sampleRate = info.sampleRate;
+    result.channels = info.channels;
+    result.bitsPerSample = info.bitsPerSample;
+    return result;
 }
 
 std::string AudioDecoderPlugin::ConvertToWav(
     const std::string& inputPath, const std::string& outputPath,
     int targetSampleRate, int targetChannels, int targetBitDepth) {
 
-    auto pcm = DecodeToPcm(inputPath, -1, -1, targetSampleRate, targetChannels, targetBitDepth);
-
-    if (pcm.data.empty()) {
-        throw std::runtime_error("No audio data decoded from input file");
-    }
-
     std::wstring wOutputPath = Utf8ToWide(outputPath);
-    std::ofstream file(wOutputPath, std::ios::binary);
+    std::fstream file(wOutputPath,
+                      std::ios::binary | std::ios::in | std::ios::out | std::ios::trunc);
     if (!file.is_open()) {
         throw std::runtime_error("Cannot open output file for writing");
     }
 
-    WriteWavHeader(file, static_cast<uint32_t>(pcm.data.size()), pcm.sampleRate,
-                   static_cast<uint16_t>(pcm.channels), static_cast<uint16_t>(pcm.bitsPerSample));
-    file.write(reinterpret_cast<char*>(pcm.data.data()), pcm.data.size());
+    // Write placeholder WAV header (dataSize = 0)
+    WriteWavHeader(file, 0, 0, 0, 0);
+
+    int64_t totalPcmBytes = 0;
+    auto info = DecodeToPcmStream(inputPath,
+        [&](const uint8_t* data, size_t size) {
+            file.write(reinterpret_cast<const char*>(data), size);
+            totalPcmBytes += static_cast<int64_t>(size);
+            if (totalPcmBytes > kMaxWavDataSize) {
+                throw std::runtime_error("WAV output exceeds maximum size (~4 GB)");
+            }
+        },
+        -1, -1, targetSampleRate, targetChannels, targetBitDepth);
+
+    if (totalPcmBytes == 0) {
+        file.close();
+        DeleteFileW(wOutputPath.c_str());
+        throw std::runtime_error("No audio data decoded from input file");
+    }
+
+    // Seek back and write final header with actual sizes
+    file.seekp(0);
+    WriteWavHeader(file, static_cast<uint32_t>(totalPcmBytes), info.sampleRate,
+                   static_cast<uint16_t>(info.channels),
+                   static_cast<uint16_t>(info.bitsPerSample));
     file.close();
 
     return outputPath;
@@ -857,13 +893,35 @@ std::string AudioDecoderPlugin::TrimAudio(
         pWriter->Release();
     } else {
         std::wstring wOutputPath = Utf8ToWide(outputPath);
-        std::ofstream file(wOutputPath, std::ios::binary);
+        std::fstream file(wOutputPath,
+                          std::ios::binary | std::ios::in | std::ios::out | std::ios::trunc);
         if (!file.is_open()) {
             throw std::runtime_error("Cannot open output file for writing");
         }
-        WriteWavHeader(file, static_cast<uint32_t>(pcm.data.size()), pcm.sampleRate,
-                       static_cast<uint16_t>(pcm.channels), static_cast<uint16_t>(pcm.bitsPerSample));
-        file.write(reinterpret_cast<char*>(pcm.data.data()), pcm.data.size());
+
+        WriteWavHeader(file, 0, 0, 0, 0);
+
+        int64_t totalPcmBytes = 0;
+        auto wavInfo = DecodeToPcmStream(inputPath,
+            [&](const uint8_t* data, size_t size) {
+                file.write(reinterpret_cast<const char*>(data), size);
+                totalPcmBytes += static_cast<int64_t>(size);
+                if (totalPcmBytes > kMaxWavDataSize) {
+                    throw std::runtime_error("WAV output exceeds maximum size (~4 GB)");
+                }
+            },
+            startMs, endMs);
+
+        if (totalPcmBytes == 0) {
+            file.close();
+            DeleteFileW(wOutputPath.c_str());
+            throw std::runtime_error("No audio data decoded from trim range");
+        }
+
+        file.seekp(0);
+        WriteWavHeader(file, static_cast<uint32_t>(totalPcmBytes), wavInfo.sampleRate,
+                       static_cast<uint16_t>(wavInfo.channels),
+                       static_cast<uint16_t>(wavInfo.bitsPerSample));
         file.close();
     }
 
@@ -919,7 +977,7 @@ flutter::EncodableList AudioDecoderPlugin::GetWaveform(
 }
 
 void AudioDecoderPlugin::WriteWavHeader(
-    std::ofstream& file, uint32_t dataSize, uint32_t sampleRate,
+    std::ostream& file, uint32_t dataSize, uint32_t sampleRate,
     uint16_t channels, uint16_t bitsPerSample) {
 
     uint32_t byteRate = sampleRate * channels * bitsPerSample / 8;

--- a/windows/audio_decoder_plugin.h
+++ b/windows/audio_decoder_plugin.h
@@ -4,6 +4,7 @@
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar_windows.h>
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <fstream>
@@ -39,10 +40,24 @@ class AudioDecoderPlugin : public flutter::Plugin {
                         int64_t startMs, int64_t endMs);
   flutter::EncodableList GetWaveform(const std::string& path,
                                      int numberOfSamples);
-  void WriteWavHeader(std::ofstream& file, uint32_t dataSize,
+  void WriteWavHeader(std::ostream& file, uint32_t dataSize,
                       uint32_t sampleRate, uint16_t channels,
                       uint16_t bitsPerSample);
-  // Helper: decode audio to PCM using IMFSourceReader
+
+  struct PcmInfo {
+      uint32_t sampleRate;
+      uint32_t channels;
+      uint32_t bitsPerSample;
+  };
+
+  // Streaming decode: calls onChunk for each decoded PCM buffer
+  PcmInfo DecodeToPcmStream(
+      const std::string& inputPath,
+      const std::function<void(const uint8_t*, size_t)>& onChunk,
+      int64_t startMs = -1, int64_t endMs = -1,
+      int targetSampleRate = -1, int targetChannels = -1,
+      int targetBitDepth = -1);
+
   struct PcmResult {
       std::vector<uint8_t> data;
       uint32_t sampleRate;

--- a/windows/audio_decoder_plugin.h
+++ b/windows/audio_decoder_plugin.h
@@ -50,6 +50,15 @@ class AudioDecoderPlugin : public flutter::Plugin {
       uint32_t bitsPerSample;
   };
 
+  /// Streams decoded PCM to a WAV file on disk. On failure the output file
+  /// is removed before rethrowing.
+  PcmInfo streamPcmToWav(const std::string& inputPath,
+                          const std::string& outputPath,
+                          int64_t startMs = -1, int64_t endMs = -1,
+                          int targetSampleRate = -1,
+                          int targetChannels = -1,
+                          int targetBitDepth = -1);
+
   // Streaming decode: calls onChunk for each decoded PCM buffer
   PcmInfo DecodeToPcmStream(
       const std::string& inputPath,

--- a/windows/audio_decoder_plugin.h
+++ b/windows/audio_decoder_plugin.h
@@ -52,7 +52,7 @@ class AudioDecoderPlugin : public flutter::Plugin {
 
   /// Streams decoded PCM to a WAV file on disk. On failure the output file
   /// is removed before rethrowing.
-  PcmInfo streamPcmToWav(const std::string& inputPath,
+  PcmInfo StreamPcmToWav(const std::string& inputPath,
                           const std::string& outputPath,
                           int64_t startMs = -1, int64_t endMs = -1,
                           int targetSampleRate = -1,


### PR DESCRIPTION
## Summary

- Introduces a callback-based `DecodeToPcmStream` function on both Linux (GStreamer) and Windows (Media Foundation) that writes each decoded PCM chunk directly to the output file instead of accumulating all data in a `std::vector<uint8_t>` before writing
- Rewrites `ConvertToWav`, `ConvertToM4a` (Linux), and `TrimAudio` (both platforms) to stream PCM to disk during decoding using placeholder WAV header + seek-back pattern
- Adds a ~4 GB WAV size guard (`kMaxWavDataSize`) consistent with Android/iOS implementations

## Test plan

- [ ] Run integration tests on Linux (`flutter test integration_test/`)
- [ ] Run integration tests on Windows (`flutter test integration_test/`)
- [ ] Verify WAV conversion produces valid, playable output
- [ ] Verify M4A conversion still works correctly on Linux
- [ ] Verify trim operations (both WAV and M4A output) produce correct results
- [ ] Profile peak memory usage with a large audio file to confirm reduction

Closes #19