### PR TITLE
Improve pub.dev discoverability and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # audio_decoder
 
 [![pub package](https://img.shields.io/pub/v/audio_decoder.svg)](https://pub.dev/packages/audio_decoder)
-[![likes](https://img.shields.io/pub/likes/audio_decoder)](https://pub.dev/packages/audio_decoder/score)
-[![pub points](https://img.shields.io/pub/points/audio_decoder)](https://pub.dev/packages/audio_decoder/score)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![pub points](https://img.shields.io/pub/points/audio_decoder)](https://pub.dev/packages/audio_decoder/score)
+[![likes](https://img.shields.io/pub/likes/audio_decoder)](https://pub.dev/packages/audio_decoder/score)
 
 A lightweight Flutter plugin for converting, trimming, and analyzing audio files using native platform APIs. No FFmpeg dependency required.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # audio_decoder
 
 [![pub package](https://img.shields.io/pub/v/audio_decoder.svg)](https://pub.dev/packages/audio_decoder)
+[![likes](https://img.shields.io/pub/likes/audio_decoder)](https://pub.dev/packages/audio_decoder/score)
+[![pub points](https://img.shields.io/pub/points/audio_decoder)](https://pub.dev/packages/audio_decoder/score)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 A lightweight Flutter plugin for converting, trimming, and analyzing audio files using native platform APIs. No FFmpeg dependency required.
 
@@ -33,7 +36,7 @@ Add `audio_decoder` to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  audio_decoder: ^0.7.0
+  audio_decoder: ^0.7.2
 ```
 
 Or install via the command line:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: audio_decoder
-description: "Decode MP3, AAC, FLAC, OGG & more to WAV/PCM using native platform APIs. Convert, trim, and analyze audio — no FFmpeg required."
+description: "Decode MP3, M4A, AAC, FLAC, OGG & more to WAV/PCM using native platform APIs. Convert, trim, and analyze audio — no FFmpeg required."
 version: 0.7.2
 homepage: https://www.silversoft.nl
 repository: https://github.com/sjoenk/audio_decoder

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,18 @@
 name: audio_decoder
-description: "A lightweight Flutter plugin for converting, trimming, and analyzing audio files using native platform APIs. No FFmpeg required."
+description: "Decode MP3, AAC, FLAC, OGG & more to WAV/PCM using native platform APIs. Convert, trim, and analyze audio — no FFmpeg required."
 version: 0.7.2
 homepage: https://www.silversoft.nl
 repository: https://github.com/sjoenk/audio_decoder
+issue_tracker: https://github.com/sjoenk/audio_decoder/issues
+funding:
+  - https://github.com/sponsors/sjoenk
+
+topics:
+  - audio
+  - audio-processing
+  - decoder
+  - pcm
+  - flutter-plugin
 
 environment:
   sdk: ^3.10.8
@@ -21,21 +31,7 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^6.0.0
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter packages.
 flutter:
-  # This section identifies this Flutter project as a plugin project.
-  # The 'pluginClass' specifies the class (in Java, Kotlin, Swift, Objective-C, etc.)
-  # which should be registered in the plugin registry. This is required for
-  # using method channels.
-  # The Android 'package' specifies package in which the registered class is.
-  # This is required for using method channels on Android.
-  # The 'ffiPlugin' specifies that native code should be built and bundled.
-  # This is required for using `dart:ffi`.
-  # All these are used by the tooling to maintain consistency when
-  # adding or updating assets for this project.
   plugin:
     platforms:
       android:
@@ -54,34 +50,3 @@ flutter:
       web:
         pluginClass: AudioDecoderWeb
         fileName: audio_decoder_web.dart
-
-  # To add assets to your plugin package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/to/asset-from-package
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/to/resolution-aware-images
-
-  # To add custom fonts to your plugin package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/to/font-from-package


### PR DESCRIPTION
## Summary
- Add `topics`, `funding`, and `issue_tracker` fields to `pubspec.yaml`
- Optimize `description` with searchable format names (MP3, AAC, FLAC, OGG, WAV/PCM)
- Remove boilerplate template comments from `pubspec.yaml`
- Add likes, pub points, and license badges to `README.md`
- Update version in Getting Started to `^0.7.2`

Closes #29

## Test plan
- [x] Verify `pubspec.yaml` passes `flutter pub publish --dry-run`
- [x] Confirm badges render correctly on GitHub