### PR TITLE
Clean up code style and documentation after SPM migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
   * Implemented on Android, iOS, macOS, Linux, and Windows.
 * Add Dart-level input validation for `convertToWav` and `convertToWavBytes` parameters.
   * `sampleRate`, `channels`, and `bitDepth` are validated before calling native code, throwing `ArgumentError` for invalid values.
-* Consolidate duplicate iOS/macOS Swift plugin code into shared source under `darwin/Classes/`.
+* Consolidate duplicate iOS/macOS Swift plugin code into shared source under `darwin/audio_decoder/Sources/audio_decoder/`.
 
 ## 0.6.0
 

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -9,6 +9,10 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+formatter:
+  page_width: 120
+  trailing_commas: preserve
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`

--- a/example/integration_test/benchmark_test.dart
+++ b/example/integration_test/benchmark_test.dart
@@ -62,8 +62,7 @@ void main() {
     }
   });
 
-  String outputPath(String name, String ext) =>
-      '${tempDir.path}/${name}_output.$ext';
+  String outputPath(String name, String ext) => '${tempDir.path}/${name}_output.$ext';
 
   void record(String label, int ms, int outputBytes) {
     final mb = (outputBytes / 1024 / 1024).toStringAsFixed(1);

--- a/example/integration_test/plugin_integration_test.dart
+++ b/example/integration_test/plugin_integration_test.dart
@@ -34,8 +34,7 @@ void main() {
   }
 
   /// Build a temp output path with the given [extension] (e.g. 'wav').
-  String tempOutputPath(String name, String extension) =>
-      '${tempDir.path}/${name}_output.$extension';
+  String tempOutputPath(String name, String extension) => '${tempDir.path}/${name}_output.$extension';
 
   // ── 1. convertToWav ─────────────────────────────────────────────────
 

--- a/example/integration_test/test_helpers.dart
+++ b/example/integration_test/test_helpers.dart
@@ -3,15 +3,11 @@ import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 
 /// Read a little-endian uint16 from [bytes] at [offset].
-int readUint16LE(Uint8List bytes, int offset) =>
-    bytes[offset] | (bytes[offset + 1] << 8);
+int readUint16LE(Uint8List bytes, int offset) => bytes[offset] | (bytes[offset + 1] << 8);
 
 /// Read a little-endian uint32 from [bytes] at [offset].
 int readUint32LE(Uint8List bytes, int offset) =>
-    bytes[offset] |
-    (bytes[offset + 1] << 8) |
-    (bytes[offset + 2] << 16) |
-    (bytes[offset + 3] << 24);
+    bytes[offset] | (bytes[offset + 1] << 8) | (bytes[offset + 2] << 16) | (bytes[offset + 3] << 24);
 
 /// Validate the WAV header structure of [bytes] and return a map with
 /// the parsed header fields.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -54,13 +54,9 @@ class _MyAppState extends State<MyApp> {
     try {
       final inputPath = await _copyAssetToTemp(assetPath);
       final inputSize = File(inputPath).lengthSync();
-      final baseName = assetPath
-          .split('/')
-          .last
-          .replaceAll(RegExp(r'\.[^.]+$'), '');
+      final baseName = assetPath.split('/').last.replaceAll(RegExp(r'\.[^.]+$'), '');
 
-      final outputPath =
-          '${Directory.systemTemp.path}/${baseName}_converted.wav';
+      final outputPath = '${Directory.systemTemp.path}/${baseName}_converted.wav';
       // Convert any audio format to WAV (lossless PCM)
       final result = await AudioDecoder.convertToWav(inputPath, outputPath);
       final outputSize = await File(result).length();
@@ -97,13 +93,9 @@ class _MyAppState extends State<MyApp> {
     try {
       final inputPath = await _copyAssetToTemp(assetPath);
       final inputSize = File(inputPath).lengthSync();
-      final baseName = assetPath
-          .split('/')
-          .last
-          .replaceAll(RegExp(r'\.[^.]+$'), '');
+      final baseName = assetPath.split('/').last.replaceAll(RegExp(r'\.[^.]+$'), '');
 
-      final outputPath =
-          '${Directory.systemTemp.path}/${baseName}_converted.m4a';
+      final outputPath = '${Directory.systemTemp.path}/${baseName}_converted.m4a';
       // Convert any audio format to M4A (compressed AAC)
       final result = await AudioDecoder.convertToM4a(inputPath, outputPath);
       final outputSize = await File(result).length();
@@ -213,10 +205,7 @@ class _MyAppState extends State<MyApp> {
     try {
       final inputPath = await _copyAssetToTemp(assetPath);
       // Extract normalized amplitude data (0.0-1.0) for waveform visualization
-      final waveform = await AudioDecoder.getWaveform(
-        inputPath,
-        numberOfSamples: 20,
-      );
+      final waveform = await AudioDecoder.getWaveform(inputPath, numberOfSamples: 20);
 
       setState(() {
         _waveform = waveform;
@@ -258,10 +247,7 @@ class _MyAppState extends State<MyApp> {
     try {
       final inputBytes = await _loadAssetBytes(assetPath);
       // Convert in-memory audio bytes to WAV format (requires formatHint)
-      final wavBytes = await AudioDecoder.convertToWavBytes(
-        inputBytes,
-        formatHint: ext,
-      );
+      final wavBytes = await AudioDecoder.convertToWavBytes(inputBytes, formatHint: ext);
 
       setState(() {
         _statusType = _StatusType.success;
@@ -294,16 +280,9 @@ class _MyAppState extends State<MyApp> {
 
     try {
       final inputBytes = await _loadAssetBytes(assetPath);
-      final wavBytes = await AudioDecoder.convertToWavBytes(
-        inputBytes,
-        formatHint: ext,
-      );
+      final wavBytes = await AudioDecoder.convertToWavBytes(inputBytes, formatHint: ext);
       // Get raw PCM data without WAV header (set includeHeader: false)
-      final pcmBytes = await AudioDecoder.convertToWavBytes(
-        inputBytes,
-        formatHint: ext,
-        includeHeader: false,
-      );
+      final pcmBytes = await AudioDecoder.convertToWavBytes(inputBytes, formatHint: ext, includeHeader: false);
 
       setState(() {
         _statusType = _StatusType.success;
@@ -337,10 +316,7 @@ class _MyAppState extends State<MyApp> {
 
     try {
       final inputBytes = await _loadAssetBytes(assetPath);
-      final info = await AudioDecoder.getAudioInfoBytes(
-        inputBytes,
-        formatHint: ext,
-      );
+      final info = await AudioDecoder.getAudioInfoBytes(inputBytes, formatHint: ext);
 
       setState(() {
         _statusType = _StatusType.success;
@@ -415,11 +391,7 @@ class _MyAppState extends State<MyApp> {
     try {
       final inputBytes = await _loadAssetBytes(assetPath);
       // Extract waveform data from in-memory audio bytes
-      final waveform = await AudioDecoder.getWaveformBytes(
-        inputBytes,
-        formatHint: ext,
-        numberOfSamples: 100,
-      );
+      final waveform = await AudioDecoder.getWaveformBytes(inputBytes, formatHint: ext, numberOfSamples: 100);
 
       setState(() {
         _waveform = waveform;
@@ -440,11 +412,7 @@ class _MyAppState extends State<MyApp> {
   // UI helpers
   // ---------------------------------------------------------------------------
 
-  Widget _sectionCard({
-    required String title,
-    required IconData icon,
-    required List<Widget> children,
-  }) {
+  Widget _sectionCard({required String title, required IconData icon, required List<Widget> children}) {
     return Card(
       margin: const EdgeInsets.only(bottom: 12),
       child: Padding(
@@ -454,11 +422,7 @@ class _MyAppState extends State<MyApp> {
           children: [
             Row(
               children: [
-                Icon(
-                  icon,
-                  size: 20,
-                  color: Theme.of(context).colorScheme.primary,
-                ),
+                Icon(icon, size: 20, color: Theme.of(context).colorScheme.primary),
                 const SizedBox(width: 8),
                 Text(title, style: Theme.of(context).textTheme.titleSmall),
               ],
@@ -471,20 +435,12 @@ class _MyAppState extends State<MyApp> {
     );
   }
 
-  Widget _actionButton({
-    required String label,
-    required IconData icon,
-    required VoidCallback? onPressed,
-  }) {
+  Widget _actionButton({required String label, required IconData icon, required VoidCallback? onPressed}) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
       child: SizedBox(
         width: double.infinity,
-        child: FilledButton.tonalIcon(
-          onPressed: onPressed,
-          icon: Icon(icon, size: 18),
-          label: Text(label),
-        ),
+        child: FilledButton.tonalIcon(onPressed: onPressed, icon: Icon(icon, size: 18), label: Text(label)),
       ),
     );
   }
@@ -505,22 +461,13 @@ class _MyAppState extends State<MyApp> {
     };
 
     final statusIcon = switch (_statusType) {
-      _StatusType.ready => Icon(
-        Icons.audio_file,
-        color: colorScheme.onSurfaceVariant,
-      ),
+      _StatusType.ready => Icon(Icons.audio_file, color: colorScheme.onSurfaceVariant),
       _StatusType.loading => SizedBox(
         width: 20,
         height: 20,
-        child: CircularProgressIndicator(
-          strokeWidth: 2.5,
-          color: colorScheme.primary,
-        ),
+        child: CircularProgressIndicator(strokeWidth: 2.5, color: colorScheme.primary),
       ),
-      _StatusType.success => Icon(
-        Icons.check_circle_outline,
-        color: colorScheme.primary,
-      ),
+      _StatusType.success => Icon(Icons.check_circle_outline, color: colorScheme.primary),
       _StatusType.error => Icon(Icons.error_outline, color: colorScheme.error),
     };
 
@@ -546,8 +493,7 @@ class _MyAppState extends State<MyApp> {
                           Expanded(
                             child: Text(
                               _status,
-                              style: Theme.of(context).textTheme.bodySmall
-                                  ?.copyWith(fontFamily: 'monospace'),
+                              style: Theme.of(context).textTheme.bodySmall?.copyWith(fontFamily: 'monospace'),
                             ),
                           ),
                         ],
@@ -559,9 +505,7 @@ class _MyAppState extends State<MyApp> {
                           decoration: BoxDecoration(
                             color: colorScheme.surfaceContainerLowest,
                             borderRadius: BorderRadius.circular(12),
-                            border: Border.all(
-                              color: colorScheme.outlineVariant,
-                            ),
+                            border: Border.all(color: colorScheme.outlineVariant),
                           ),
                           padding: const EdgeInsets.symmetric(vertical: 2),
                           clipBehavior: Clip.antiAlias,
@@ -594,23 +538,17 @@ class _MyAppState extends State<MyApp> {
                         _actionButton(
                           label: 'MP3 → WAV',
                           icon: Icons.audio_file,
-                          onPressed: _busy
-                              ? null
-                              : () => _convertToWav(_kTestToneMp3),
+                          onPressed: _busy ? null : () => _convertToWav(_kTestToneMp3),
                         ),
                         _actionButton(
                           label: 'M4A → WAV',
                           icon: Icons.audio_file,
-                          onPressed: _busy
-                              ? null
-                              : () => _convertToWav(_kTestToneM4a),
+                          onPressed: _busy ? null : () => _convertToWav(_kTestToneM4a),
                         ),
                         _actionButton(
                           label: 'WAV → M4A',
                           icon: Icons.audio_file,
-                          onPressed: _busy
-                              ? null
-                              : () => _convertToM4a(_kTestToneWav),
+                          onPressed: _busy ? null : () => _convertToM4a(_kTestToneWav),
                         ),
                       ],
                     ),
@@ -621,16 +559,12 @@ class _MyAppState extends State<MyApp> {
                         _actionButton(
                           label: 'Get Audio Info (MP3)',
                           icon: Icons.info_outline,
-                          onPressed: _busy
-                              ? null
-                              : () => _getAudioInfo(_kTestToneMp3),
+                          onPressed: _busy ? null : () => _getAudioInfo(_kTestToneMp3),
                         ),
                         _actionButton(
                           label: 'Get Waveform (MP3)',
                           icon: Icons.graphic_eq,
-                          onPressed: _busy
-                              ? null
-                              : () => _getWaveform(_kTestToneMp3),
+                          onPressed: _busy ? null : () => _getWaveform(_kTestToneMp3),
                         ),
                       ],
                     ),
@@ -641,9 +575,7 @@ class _MyAppState extends State<MyApp> {
                         _actionButton(
                           label: 'Trim MP3 (0.2s – 0.8s) → WAV',
                           icon: Icons.content_cut,
-                          onPressed: _busy
-                              ? null
-                              : () => _trimAudio(_kTestToneMp3),
+                          onPressed: _busy ? null : () => _trimAudio(_kTestToneMp3),
                         ),
                       ],
                     ),
@@ -654,37 +586,27 @@ class _MyAppState extends State<MyApp> {
                         _actionButton(
                           label: 'MP3 → WAV (bytes)',
                           icon: Icons.swap_horiz,
-                          onPressed: _busy
-                              ? null
-                              : () => _convertToWavBytes(_kTestToneMp3),
+                          onPressed: _busy ? null : () => _convertToWavBytes(_kTestToneMp3),
                         ),
                         _actionButton(
                           label: 'MP3 → raw PCM (bytes)',
                           icon: Icons.data_array,
-                          onPressed: _busy
-                              ? null
-                              : () => _convertToRawPcmBytes(_kTestToneMp3),
+                          onPressed: _busy ? null : () => _convertToRawPcmBytes(_kTestToneMp3),
                         ),
                         _actionButton(
                           label: 'Get Audio Info (bytes)',
                           icon: Icons.info_outline,
-                          onPressed: _busy
-                              ? null
-                              : () => _getAudioInfoBytes(_kTestToneMp3),
+                          onPressed: _busy ? null : () => _getAudioInfoBytes(_kTestToneMp3),
                         ),
                         _actionButton(
                           label: 'Trim MP3 (0.2s – 0.8s, bytes)',
                           icon: Icons.content_cut,
-                          onPressed: _busy
-                              ? null
-                              : () => _trimAudioBytes(_kTestToneMp3),
+                          onPressed: _busy ? null : () => _trimAudioBytes(_kTestToneMp3),
                         ),
                         _actionButton(
                           label: 'Get Waveform (bytes)',
                           icon: Icons.graphic_eq,
-                          onPressed: _busy
-                              ? null
-                              : () => _getWaveformBytes(_kTestToneMp3),
+                          onPressed: _busy ? null : () => _getWaveformBytes(_kTestToneMp3),
                         ),
                       ],
                     ),
@@ -705,11 +627,7 @@ class _WaveformPainter extends CustomPainter {
   final Color color;
   final Color accentColor;
 
-  _WaveformPainter(
-    this.waveform, {
-    required this.color,
-    required this.accentColor,
-  });
+  _WaveformPainter(this.waveform, {required this.color, required this.accentColor});
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -728,11 +646,7 @@ class _WaveformPainter extends CustomPainter {
       final x = i * barWidth;
       canvas.drawRRect(
         RRect.fromRectAndRadius(
-          Rect.fromCenter(
-            center: Offset(x + barWidth / 2, midY),
-            width: barWidth * 0.7,
-            height: barHeight * 2,
-          ),
+          Rect.fromCenter(center: Offset(x + barWidth / 2, midY), width: barWidth * 0.7, height: barHeight * 2),
           radius,
         ),
         paint,
@@ -742,7 +656,5 @@ class _WaveformPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(_WaveformPainter old) =>
-      old.waveform != waveform ||
-      old.color != color ||
-      old.accentColor != accentColor;
+      old.waveform != waveform || old.color != color || old.accentColor != accentColor;
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,6 +4,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:audio_decoder/audio_decoder.dart';
 
+const _kTestToneMp3 = 'assets/test_tone.mp3';
+const _kTestToneM4a = 'assets/test_tone.m4a';
+const _kTestToneWav = 'assets/test_tone.wav';
+
 enum _StatusType { ready, loading, success, error }
 
 void main() {
@@ -211,7 +215,7 @@ class _MyAppState extends State<MyApp> {
       // Extract normalized amplitude data (0.0-1.0) for waveform visualization
       final waveform = await AudioDecoder.getWaveform(
         inputPath,
-        numberOfSamples: 100,
+        numberOfSamples: 20,
       );
 
       setState(() {
@@ -592,21 +596,21 @@ class _MyAppState extends State<MyApp> {
                           icon: Icons.audio_file,
                           onPressed: _busy
                               ? null
-                              : () => _convertToWav('assets/test_tone.mp3'),
+                              : () => _convertToWav(_kTestToneMp3),
                         ),
                         _actionButton(
                           label: 'M4A → WAV',
                           icon: Icons.audio_file,
                           onPressed: _busy
                               ? null
-                              : () => _convertToWav('assets/test_tone.m4a'),
+                              : () => _convertToWav(_kTestToneM4a),
                         ),
                         _actionButton(
                           label: 'WAV → M4A',
                           icon: Icons.audio_file,
                           onPressed: _busy
                               ? null
-                              : () => _convertToM4a('assets/test_tone.wav'),
+                              : () => _convertToM4a(_kTestToneWav),
                         ),
                       ],
                     ),
@@ -619,14 +623,14 @@ class _MyAppState extends State<MyApp> {
                           icon: Icons.info_outline,
                           onPressed: _busy
                               ? null
-                              : () => _getAudioInfo('assets/test_tone.mp3'),
+                              : () => _getAudioInfo(_kTestToneMp3),
                         ),
                         _actionButton(
                           label: 'Get Waveform (MP3)',
                           icon: Icons.graphic_eq,
                           onPressed: _busy
                               ? null
-                              : () => _getWaveform('assets/test_tone.mp3'),
+                              : () => _getWaveform(_kTestToneMp3),
                         ),
                       ],
                     ),
@@ -639,7 +643,7 @@ class _MyAppState extends State<MyApp> {
                           icon: Icons.content_cut,
                           onPressed: _busy
                               ? null
-                              : () => _trimAudio('assets/test_tone.mp3'),
+                              : () => _trimAudio(_kTestToneMp3),
                         ),
                       ],
                     ),
@@ -652,39 +656,35 @@ class _MyAppState extends State<MyApp> {
                           icon: Icons.swap_horiz,
                           onPressed: _busy
                               ? null
-                              : () =>
-                                    _convertToWavBytes('assets/test_tone.mp3'),
+                              : () => _convertToWavBytes(_kTestToneMp3),
                         ),
                         _actionButton(
                           label: 'MP3 → raw PCM (bytes)',
                           icon: Icons.data_array,
                           onPressed: _busy
                               ? null
-                              : () => _convertToRawPcmBytes(
-                                  'assets/test_tone.mp3',
-                                ),
+                              : () => _convertToRawPcmBytes(_kTestToneMp3),
                         ),
                         _actionButton(
                           label: 'Get Audio Info (bytes)',
                           icon: Icons.info_outline,
                           onPressed: _busy
                               ? null
-                              : () =>
-                                    _getAudioInfoBytes('assets/test_tone.mp3'),
+                              : () => _getAudioInfoBytes(_kTestToneMp3),
                         ),
                         _actionButton(
                           label: 'Trim MP3 (0.2s – 0.8s, bytes)',
                           icon: Icons.content_cut,
                           onPressed: _busy
                               ? null
-                              : () => _trimAudioBytes('assets/test_tone.mp3'),
+                              : () => _trimAudioBytes(_kTestToneMp3),
                         ),
                         _actionButton(
                           label: 'Get Waveform (bytes)',
                           icon: Icons.graphic_eq,
                           onPressed: _busy
                               ? null
-                              : () => _getWaveformBytes('assets/test_tone.mp3'),
+                              : () => _getWaveformBytes(_kTestToneMp3),
                         ),
                       ],
                     ),


### PR DESCRIPTION
## Summary
- Correct outdated source path in CHANGELOG 0.7.0 entry after SPM restructuring
- Extract hardcoded asset paths into top-level constants in example app
- Unify formatter settings (page_width: 120) across root and example projects
- Reformat example Dart files with correct line width

Related to #33

## Changes
- **CHANGELOG.md**: Fix `darwin/Classes/` → `darwin/audio_decoder/Sources/audio_decoder/` in 0.7.0 entry
- **example/analysis_options.yaml**: Add `page_width: 120` and `trailing_commas: preserve` to match root project
- **example/lib/main.dart**: Replace hardcoded `'assets/test_tone.*'` strings with constants, reformat to 120 width
- **example/integration_test/**: Reformat to 120 character width

## Test plan
- [x] `flutter analyze` passes with no issues
- [x] `dart format` produces no changes
- [x] Example app builds and runs on iOS/macOS

## Time spent
⏱️ Estimated time spent: 1 hour