### PR TITLE
Fix build failures on Linux and Windows 

### DIFF
--- a/linux/audio_decoder_plugin.cc
+++ b/linux/audio_decoder_plugin.cc
@@ -583,9 +583,16 @@ static FlValue* GetWaveform(const std::string& path, int numberOfSamples) {
     (G_TYPE_CHECK_INSTANCE_CAST((obj), audio_decoder_plugin_get_type(), \
                                 AudioDecoderPlugin))
 
+typedef struct _AudioDecoderPlugin AudioDecoderPlugin;
+typedef struct _AudioDecoderPluginClass AudioDecoderPluginClass;
+
 struct _AudioDecoderPlugin {
     GObject parent_instance;
     FlMethodChannel* channel;
+};
+
+struct _AudioDecoderPluginClass {
+    GObjectClass parent_class;
 };
 
 G_DEFINE_TYPE(AudioDecoderPlugin, audio_decoder_plugin, g_object_get_type())

--- a/windows/audio_decoder_plugin.cpp
+++ b/windows/audio_decoder_plugin.cpp
@@ -19,6 +19,7 @@
 #include <functional>
 #include <cmath>
 #include <algorithm>
+#include <cctype> 
 
 #pragma comment(lib, "mfplat.lib")
 #pragma comment(lib, "mfreadwrite.lib")
@@ -847,7 +848,7 @@ std::string AudioDecoderPlugin::TrimAudio(
     std::string ext = outputPath.substr(outputPath.find_last_of('.') + 1);
     std::transform(ext.begin(), ext.end(), ext.begin(),
 		    [](unsigned char c) {
-		    	return static_cast<char>(std::tolower());
+		    	return static_cast<char>(std::tolower(c));
 		});
 
     if (ext == "m4a") {

--- a/windows/audio_decoder_plugin.cpp
+++ b/windows/audio_decoder_plugin.cpp
@@ -777,7 +777,7 @@ flutter::EncodableMap AudioDecoderPlugin::GetAudioInfo(const std::string& path) 
 
     IMFMediaSource* pSource = nullptr;
     hr = pReader->GetServiceForStream(
-        MF_SOURCE_READER_MEDIASOURCE, GUID_NULL,
+        static_cast<DWORD>(MF_SOURCE_READER_MEDIASOURCE), GUID_NULL,
         __uuidof(IMFMediaSource), reinterpret_cast<LPVOID*>(&pSource));
     if (SUCCEEDED(hr) && pSource) {
         IMFPresentationDescriptor* pPD = nullptr;
@@ -902,7 +902,7 @@ std::string AudioDecoderPlugin::TrimAudio(
 
         for (size_t offset = 0; offset < pcm.data.size(); offset += chunkSize) {
             DWORD thisChunk = static_cast<DWORD>(
-                std::min(static_cast<size_t>(chunkSize), pcm.data.size() - offset));
+                (std::min)(static_cast<size_t>(chunkSize), pcm.data.size() - offset));
 
             IMFMediaBuffer* pBuffer = nullptr;
             MFCreateMemoryBuffer(thisChunk, &pBuffer);
@@ -950,14 +950,14 @@ flutter::EncodableList AudioDecoderPlugin::GetWaveform(
 
     const int16_t* samples = reinterpret_cast<const int16_t*>(pcm.data.data());
     size_t totalSamples = pcm.data.size() / 2;
-    size_t samplesPerWindow = std::max(static_cast<size_t>(1), totalSamples / numberOfSamples);
+    size_t samplesPerWindow = (std::max)(static_cast<size_t>(1), totalSamples / numberOfSamples);
 
     std::vector<double> waveform;
     double maxRms = 0;
 
     for (int i = 0; i < numberOfSamples; i++) {
         size_t start = static_cast<size_t>(i) * totalSamples / numberOfSamples;
-        size_t end = std::min(start + samplesPerWindow, totalSamples);
+        size_t end = (std::min)(start + samplesPerWindow, totalSamples);
         if (start >= totalSamples) break;
 
         double sumSquares = 0;

--- a/windows/audio_decoder_plugin.cpp
+++ b/windows/audio_decoder_plugin.cpp
@@ -845,7 +845,10 @@ std::string AudioDecoderPlugin::TrimAudio(
     }
 
     std::string ext = outputPath.substr(outputPath.find_last_of('.') + 1);
-    std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+    std::transform(ext.begin(), ext.end(), ext.begin(),
+		    [](unsigned char c) {
+		    	return static_cast<char>(std::tolower());
+		});
 
     if (ext == "m4a") {
         // M4A trimming uses DecodeToPcm (full buffering) because

--- a/windows/audio_decoder_plugin.h
+++ b/windows/audio_decoder_plugin.h
@@ -3,6 +3,7 @@
 
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar_windows.h>
+#include <flutter/encodable_value.h>
 
 #include <functional>
 #include <memory>


### PR DESCRIPTION
### Description
This PR resolves build issues on both Linux and Windows when compiling the plugin with newer compilers. 

### Changes Included

**1. Linux Build Fix**
- **Issue:** 
  - With GCC 15.2.1 compiler, the `G_DEFINE_TYPE` macro fails when the required class and instance types are not declared beforehand. This results in undefined type errors and prevents the plugin from building correctly, potentially leading to a `MissingPluginException` at runtime.
- **Fix:** 
  - Added explicit forward `typedef` declarations for `_AudioDecoderPlugin` and `_AudioDecoderPluginClass` before the struct definitions so the macro can resolve the types correctly.

**2. Windows Build Fix**
- **Issues:** 
  - MSVC defines legacy `min` and `max` macros via `<windows.h>`, which conflict with `std::min` and `std::max`, causing `C2589` and `C2059` compilation errors. 
  - `C4245` warning caused by an implicit conversion when passing `MF_SOURCE_READER_MEDIASOURCE` to a `DWORD`.
  - In newer Flutter Windows SDK version, `flutter::EncodableMap` and `flutter::EncodableList` types no longer transitively included via `standart_method_codec.h` and without fix it gives compilation error.
  - `std::tolower` returns `int`, assignment to `char` caused possible data loss warning. 
- **Fixes:** 
  - Wrapped `std::min` and `std::max` calls in parentheses (e.g. `(std::min)(...)`) to avoid macro expansion conflicts.
  - Added an explicit `static_cast<DWORD>` for `MF_SOURCE_READER_MEDIASOURCE` to match the expected type.
  - Added necessary library import into `audio_decoder_plugin.h`
  - Explicitly cast result to `char`, use `unsigned char` input to avoidd undefined behaviour for negative `char` values.

### Environment Tested
- **Linux:** GCC 15.2.1
- **Windows:** MSVC toolchain

Fixes #40
